### PR TITLE
TASK 1-A-1 implement basic world container

### DIFF
--- a/agent_world/core/world.py
+++ b/agent_world/core/world.py
@@ -1,1 +1,49 @@
-# Placeholder
+"""Simple world container for core managers and tile map."""
+
+from __future__ import annotations
+
+from typing import List, Tuple, Any
+
+
+class World:
+    """Lightweight holder for tile map and manager references."""
+
+    def __init__(self, size: Tuple[int, int]):
+        self.size: Tuple[int, int] = size
+        width, height = size
+        self.tile_map: List[List[Any]] = [
+            [None for _ in range(width)] for _ in range(height)
+        ]
+
+        # These managers will be populated during the bootstrapping phase.
+        self.entity_manager = None
+        self.component_manager = None
+        self.systems_manager = None
+        self.time_manager = None
+        self.spatial_index = None
+
+    # ------------------------------------------------------------------
+    # Entity operations
+    # ------------------------------------------------------------------
+    def add_entity(self, entity_id: int) -> None:
+        """Stub for adding an entity to the world."""
+        if self.entity_manager is not None:
+            self.entity_manager.create_entity(entity_id)  # type: ignore[attr-defined]
+
+    def remove_entity(self, entity_id: int) -> None:
+        """Stub for removing an entity from the world."""
+        if self.entity_manager is not None:
+            self.entity_manager.destroy_entity(entity_id)  # type: ignore[attr-defined]
+
+    # ------------------------------------------------------------------
+    # System operations
+    # ------------------------------------------------------------------
+    def register_system(self, system: Any) -> None:
+        """Stub for registering a system."""
+        if self.systems_manager is not None:
+            self.systems_manager.register(system)  # type: ignore[attr-defined]
+
+    def unregister_system(self, system: Any) -> None:
+        """Stub for unregistering a system."""
+        if self.systems_manager is not None:
+            self.systems_manager.unregister(system)  # type: ignore[attr-defined]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,2 +1,21 @@
-def test_placeholder():
-    assert True
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agent_world.core.world import World
+
+
+def test_world_init_tile_map():
+    w = World((3, 4))
+    assert len(w.tile_map) == 4
+    assert all(len(row) == 3 for row in w.tile_map)
+
+
+def test_world_stub_methods():
+    w = World((1, 1))
+    # Should not raise
+    w.add_entity(1)
+    w.remove_entity(1)
+    w.register_system(object())
+    w.unregister_system(object())


### PR DESCRIPTION
## Summary
- implement minimal `World` class with tile map and manager references
- add stubbed entity and system registration helpers
- create basic tests for world construction and stubs

## Testing
- `pytest -q`
- `python main.py`