### PR TITLE
TASK 3-A-1: stub LLM manager with queue and cache

### DIFF
--- a/agent_world/ai/llm/cache.py
+++ b/agent_world/ai/llm/cache.py
@@ -1,1 +1,44 @@
-# Placeholder
+"""Simple in-memory LRU cache for LLM prompts."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import OrderedDict as OrderedDictType
+
+
+class LLMCache:
+    """LRU cache keyed by prompt strings."""
+
+    def __init__(self, capacity: int = 1000) -> None:
+        self.capacity = capacity
+        self._store: OrderedDictType[str, str] = OrderedDict()
+
+    # ------------------------------------------------------------------
+    # Basic operations
+    # ------------------------------------------------------------------
+    def get(self, prompt: str) -> str | None:
+        """Return cached response for ``prompt`` or ``None``."""
+
+        if prompt in self._store:
+            value = self._store.pop(prompt)
+            self._store[prompt] = value
+            return value
+        return None
+
+    def put(self, prompt: str, response: str) -> None:
+        """Insert ``prompt`` → ``response`` pair, evicting LRU if needed."""
+
+        if prompt in self._store:
+            self._store.pop(prompt)
+        elif len(self._store) >= self.capacity:
+            self._store.popitem(last=False)
+        self._store[prompt] = response
+
+    def __contains__(self, prompt: str) -> bool:  # pragma: no cover - trivial
+        return prompt in self._store
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._store)
+
+
+__all__ = ["LLMCache"]

--- a/agent_world/ai/llm/llm_manager.py
+++ b/agent_world/ai/llm/llm_manager.py
@@ -1,1 +1,57 @@
-# Placeholder
+"""LLM request queue and cache manager."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Tuple
+
+from .cache import LLMCache
+
+
+class LLMManager:
+    """Manage prompt requests through an async queue with caching."""
+
+    def __init__(self, cache_size: int = 1000, queue_max: int = 128) -> None:
+        self.cache = LLMCache(capacity=cache_size)
+        self.queue: asyncio.Queue[Tuple[str, asyncio.Future[str]]] = asyncio.Queue(
+            maxsize=queue_max
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def request(self, prompt: str) -> str:
+        """Enqueue ``prompt`` if not cached; return cached response or ``"<wait>"``."""
+
+        cached = self.cache.get(prompt)
+        if cached is not None:
+            return cached
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - no running loop
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        fut: asyncio.Future[str] = loop.create_future()
+        try:
+            self.queue.put_nowait((prompt, fut))
+        except asyncio.QueueFull:
+            # Drop the request if the queue is saturated
+            return "<wait>"
+        return "<wait>"
+
+    async def process_queue_once(self) -> None:
+        """Handle a single queued prompt and populate the cache."""
+
+        if self.queue.empty():
+            return
+
+        prompt, fut = await self.queue.get()
+        result = "<wait>"  # Stubbed response
+        self.cache.put(prompt, result)
+        if not fut.done():
+            fut.set_result(result)
+        self.queue.task_done()
+
+
+__all__ = ["LLMManager"]

--- a/tests/test_ai_llm.py
+++ b/tests/test_ai_llm.py
@@ -1,2 +1,31 @@
-def test_placeholder():
-    assert True
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from agent_world.ai.llm.cache import LLMCache
+from agent_world.ai.llm.llm_manager import LLMManager
+
+
+def test_lru_cache_eviction():
+    cache = LLMCache(capacity=2)
+    cache.put("a", "A")
+    cache.put("b", "B")
+    assert cache.get("a") == "A"
+    cache.put("c", "C")
+    assert cache.get("b") is None
+    assert cache.get("a") == "A"
+    assert cache.get("c") == "C"
+
+
+def test_llm_manager_queue_and_cache():
+    manager = LLMManager(cache_size=2, queue_max=2)
+    assert manager.request("hello") == "<wait>"
+    assert manager.queue.qsize() == 1
+
+    asyncio.run(manager.process_queue_once())
+    assert manager.request("hello") == "<wait>"
+    assert manager.queue.qsize() == 0


### PR DESCRIPTION
## Summary
- add in-memory LRU cache implementation
- build LLMManager with async queue stub
- cover manager and cache behaviour with tests

## Testing
- `pytest -q`