### PR TITLE
TASK 3-A-3: implement AI reasoning queue

### DIFF
--- a/agent_world/systems/ai/ai_reasoning_system.py
+++ b/agent_world/systems/ai/ai_reasoning_system.py
@@ -1,1 +1,42 @@
-# Placeholder
+"""Basic LLM reasoning loop for AI-controlled agents."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from ...core.components.ai_state import AIState
+from ...ai.llm.prompt_builder import build_prompt
+from ...ai.llm.llm_manager import LLMManager
+
+
+class AIReasoningSystem:
+    """Query the LLM for each agent and queue resulting actions."""
+
+    def __init__(self, world: Any, llm: LLMManager, action_queue: List[str]) -> None:
+        self.world = world
+        self.llm = llm
+        self.action_queue = action_queue
+
+    # ------------------------------------------------------------------
+    # Update
+    # ------------------------------------------------------------------
+    def update(self, tick: int) -> None:
+        """Build prompts for agents and enqueue LLM completions."""
+
+        if self.world.entity_manager is None or self.world.component_manager is None:
+            return
+
+        em = self.world.entity_manager
+        cm = self.world.component_manager
+
+        for entity_id in list(em.all_entities.keys()):
+            state = cm.get_component(entity_id, AIState)
+            if state is None:
+                continue
+
+            prompt = build_prompt(entity_id, self.world)
+            action_str = self.llm.request(prompt, timeout=0.05)
+            self.action_queue.append(action_str)
+
+
+__all__ = ["AIReasoningSystem"]

--- a/tests/test_systems_ai.py
+++ b/tests/test_systems_ai.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.components.ai_state import AIState
+
+
+def test_ai_reasoning_enqueues_actions(monkeypatch):
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+
+    e1 = world.entity_manager.create_entity()
+    e2 = world.entity_manager.create_entity()
+    world.component_manager.add_component(e1, AIState(personality="a"))
+    world.component_manager.add_component(e2, AIState(personality="b"))
+
+    built_prompts: list[int] = []
+
+    def dummy_build_prompt(agent_id: int, world_view: Any) -> str:
+        built_prompts.append(agent_id)
+        return f"prompt-{agent_id}"
+
+    monkeypatch.setattr(
+        "agent_world.ai.llm.prompt_builder.build_prompt",
+        dummy_build_prompt,
+        raising=False,
+    )
+
+    class DummyLLMManager:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, float]] = []
+
+        def request(self, prompt: str, timeout: float) -> str:
+            self.calls.append((prompt, timeout))
+            return f"ACK {prompt}"
+
+    monkeypatch.setattr(
+        "agent_world.ai.llm.llm_manager.LLMManager", DummyLLMManager, raising=False
+    )
+
+    from agent_world.systems.ai.ai_reasoning_system import AIReasoningSystem
+
+    llm = DummyLLMManager()
+    actions: list[str] = []
+    system = AIReasoningSystem(world, llm, actions)
+    system.update(tick=1)
+
+    assert actions == ["ACK prompt-1", "ACK prompt-2"]
+    assert all(t == 0.05 for _, t in llm.calls)
+    assert built_prompts == [e1, e2]


### PR DESCRIPTION
## Summary
- implement `AIReasoningSystem` to build prompts and enqueue LLM actions
- add unit test exercising prompt building and action queuing

## Testing
- `pytest -q`