### PR TITLE
Task 4-A-3: add replay module

### DIFF
--- a/agent_world/persistence/replay.py
+++ b/agent_world/persistence/replay.py
@@ -1,1 +1,74 @@
-# Placeholder
+"""Utility for deterministic event replay."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List
+
+from ..systems.combat.combat_system import CombatSystem
+from ..systems.combat.damage_types import DamageType
+
+# Event type alias for readability
+Event = Dict[str, Any]
+# Callback signature used for applying an event to the world
+EventHandler = Callable[[Any, Event, List[Event]], None]
+
+
+def _default_handlers() -> Dict[str, EventHandler]:
+    """Return built-in handlers for core event types."""
+
+    def _handle_attack(world: Any, event: Event, log: List[Event]) -> None:
+        """Replay a combat attack event."""
+
+        cs = CombatSystem(world, log)
+        damage_type = DamageType[event.get("damage_type", "MELEE")]
+        cs.attack(
+            attacker=event["attacker"],
+            target=event["target"],
+            damage_type=damage_type,
+            tick=event.get("tick"),
+        )
+
+    return {"attack": _handle_attack}
+
+
+def replay(
+    world_factory: Callable[[], Any],
+    events: Iterable[Event],
+    handlers: Dict[str, EventHandler] | None = None,
+) -> tuple[Any, bool]:
+    """Re-run events against a fresh world and verify determinism.
+
+    Parameters
+    ----------
+    world_factory:
+        Callable returning a new world instance configured for the test.
+    events:
+        Iterable of events previously produced by the world.
+    handlers:
+        Optional mapping of ``event_type`` strings to replay callbacks.
+
+    Returns
+    -------
+    tuple[Any, bool]
+        The new world after replay and ``True`` if the produced event log
+        matches ``events`` exactly.
+    """
+
+    events_list = list(events)
+    world = world_factory()
+    tm = getattr(world, "time_manager", None)
+    handlers = handlers or _default_handlers()
+
+    out_log: List[Event] = []
+    for event in events_list:
+        tick = event.get("tick")
+        if tm is not None and tick is not None:
+            tm.tick_counter = tick
+        handler = handlers.get(event.get("type"))
+        if handler is not None:
+            handler(world, event, out_log)
+
+    return world, out_log == events_list
+
+
+__all__ = ["replay", "Event", "EventHandler"]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,41 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.position import Position
+from agent_world.core.components.health import Health
+from agent_world.systems.combat.combat_system import CombatSystem
+from agent_world.persistence.replay import replay
+
+
+def _make_world() -> World:
+    w = World((5, 5))
+    w.entity_manager = EntityManager()
+    w.component_manager = ComponentManager()
+    w.time_manager = TimeManager()
+    em = w.entity_manager
+    cm = w.component_manager
+    attacker = em.create_entity()
+    target = em.create_entity()
+    cm.add_component(attacker, Position(0, 0))
+    cm.add_component(target, Position(1, 0))
+    cm.add_component(target, Health(cur=20, max=20))
+    return w
+
+
+def test_replay_attack_event_determinism():
+    world = _make_world()
+    em = world.entity_manager
+    cm = world.component_manager
+
+    combat = CombatSystem(world)
+    combat.attack(1, 2, tick=1)
+    log = list(combat.event_log)
+
+    def world_factory() -> World:
+        return _make_world()
+
+    new_world, same = replay(world_factory, log)
+    assert same
+    hp = new_world.component_manager.get_component(2, Health)
+    assert hp.cur == 10


### PR DESCRIPTION
## Summary
- implement `replay` helper to rerun combat events
- test deterministic replay of combat attacks

## Testing
- `pytest -q`