### PR TITLE
TASK 8-A-1: expand combat defense & events

### DIFF
--- a/agent_world/systems/combat/defense.py
+++ b/agent_world/systems/combat/defense.py
@@ -1,1 +1,32 @@
-# Placeholder
+"""Defense component helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from .damage_types import DamageType
+
+
+@dataclass
+class Defense:
+    """Per-damage-type armor and dodge chances."""
+
+    armor: Dict[DamageType, int] = field(default_factory=dict)
+    dodge: Dict[DamageType, float] = field(default_factory=dict)
+
+
+def armor_vs(defense: Defense, damage_type: DamageType) -> int:
+    """Return armor value against ``damage_type``."""
+
+    return defense.armor.get(damage_type, 0)
+
+
+def dodge_vs(defense: Defense, damage_type: DamageType) -> float:
+    """Return dodge chance against ``damage_type``."""
+
+    return defense.dodge.get(damage_type, 0.0)
+
+
+__all__ = ["Defense", "armor_vs", "dodge_vs"]
+

--- a/tests/test_systems_combat.py
+++ b/tests/test_systems_combat.py
@@ -5,6 +5,7 @@ from agent_world.core.components.position import Position
 from agent_world.core.components.health import Health
 from agent_world.systems.combat.combat_system import CombatSystem
 from agent_world.systems.combat.damage_types import DamageType
+from agent_world.systems.combat.defense import Defense
 
 
 def _setup_world() -> World:
@@ -59,4 +60,73 @@ def test_melee_attack_out_of_range():
     hp = cm.get_component(target, Health)
     assert hp.cur == 15
     assert combat.event_log == []
+
+
+def test_armor_reduces_damage():
+    world = _setup_world()
+    em = world.entity_manager
+    cm = world.component_manager
+
+    attacker = em.create_entity()
+    target = em.create_entity()
+
+    cm.add_component(attacker, Position(0, 0))
+    cm.add_component(target, Position(1, 0))
+    cm.add_component(target, Health(cur=20, max=20))
+    cm.add_component(target, Defense(armor={DamageType.MELEE: 4}))
+
+    combat = CombatSystem(world)
+    assert combat.attack(attacker, target, DamageType.MELEE)
+
+    hp = cm.get_component(target, Health)
+    assert hp.cur == 14
+    assert combat.event_log[-1]["damage"] == 6
+
+
+def test_dodge_prevents_damage():
+    world = _setup_world()
+    em = world.entity_manager
+    cm = world.component_manager
+
+    attacker = em.create_entity()
+    target = em.create_entity()
+
+    cm.add_component(attacker, Position(0, 0))
+    cm.add_component(target, Position(1, 0))
+    cm.add_component(target, Health(cur=20, max=20))
+    cm.add_component(target, Defense(dodge={DamageType.MELEE: 1.0}))
+
+    combat = CombatSystem(world)
+    assert combat.attack(attacker, target, DamageType.MELEE)
+
+    hp = cm.get_component(target, Health)
+    assert hp.cur == 20
+    assert combat.event_log[-1]["damage"] == 0
+    assert combat.event_log[-1]["dodged"]
+
+
+def test_death_event_emitted():
+    world = _setup_world()
+    em = world.entity_manager
+    cm = world.component_manager
+
+    attacker = em.create_entity()
+    target = em.create_entity()
+
+    cm.add_component(attacker, Position(0, 0))
+    cm.add_component(target, Position(1, 0))
+    cm.add_component(target, Health(cur=5, max=20))
+
+    combat = CombatSystem(world)
+    assert combat.attack(attacker, target, DamageType.MELEE, tick=2)
+
+    hp = cm.get_component(target, Health)
+    assert hp.cur == 0
+    assert combat.event_log[-2]["type"] == "attack"
+    assert combat.event_log[-1] == {
+        "type": "death",
+        "entity": target,
+        "killer": attacker,
+        "tick": 2,
+    }
 


### PR DESCRIPTION
## Summary
- implement `Defense` component with armor and dodge helpers
- enhance `CombatSystem.attack` with armor, dodge, and death events
- add tests for armor, dodge and death event logic

## Testing
- `pytest -q`