### PR TITLE
TASK 8-A-3: implement obstacles and collision

### DIFF
--- a/agent_world/systems/movement/movement_system.py
+++ b/agent_world/systems/movement/movement_system.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from .pathfinding import is_blocked
+
 from ...core.components.position import Position
 
 
@@ -31,6 +33,7 @@ class MovementSystem:
         em = getattr(self.world, "entity_manager", None)
         cm = getattr(self.world, "component_manager", None)
         index = getattr(self.world, "spatial_index", None)
+        size = getattr(self.world, "size", (0, 0))
         if em is None or cm is None or index is None:
             return
 
@@ -41,8 +44,17 @@ class MovementSystem:
                 continue
 
             old_pos = (pos.x, pos.y)
-            pos.x += vel.dx
-            pos.y += vel.dy
+
+            new_x = pos.x + vel.dx
+            new_y = pos.y + vel.dy
+            width, height = size
+            if (
+                0 <= new_x < width
+                and 0 <= new_y < height
+                and not is_blocked((new_x, new_y))
+            ):
+                pos.x = new_x
+                pos.y = new_y
 
             if old_pos != (pos.x, pos.y):
                 index.remove(entity_id)

--- a/agent_world/systems/movement/pathfinding.py
+++ b/agent_world/systems/movement/pathfinding.py
@@ -3,10 +3,32 @@
 from __future__ import annotations
 
 from heapq import heappop, heappush
-from typing import Dict, List, Tuple
+from typing import Dict, Iterable, List, Set, Tuple
 
 
 Coord = Tuple[int, int]
+
+# Global obstacle coordinates used by movement and pathfinding.
+OBSTACLES: Set[Coord] = set()
+
+
+def set_obstacles(obstacles: Iterable[Coord]) -> None:
+    """Replace the global obstacle set."""
+
+    OBSTACLES.clear()
+    OBSTACLES.update(obstacles)
+
+
+def clear_obstacles() -> None:
+    """Remove all obstacles from the grid."""
+
+    OBSTACLES.clear()
+
+
+def is_blocked(node: Coord) -> bool:
+    """Return ``True`` if ``node`` is blocked."""
+
+    return node in OBSTACLES
 
 
 def _heuristic(a: Coord, b: Coord) -> float:
@@ -19,10 +41,11 @@ def _heuristic(a: Coord, b: Coord) -> float:
 
 
 def _neighbors(node: Coord) -> List[Coord]:
-    """Return the cardinal neighbours of ``node``."""
+    """Return the walkable cardinal neighbours of ``node``."""
 
     x, y = node
-    return [(x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)]
+    candidates = [(x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)]
+    return [c for c in candidates if not is_blocked(c)]
 
 
 def _reconstruct(came_from: Dict[Coord, Coord], current: Coord) -> List[Coord]:
@@ -43,6 +66,9 @@ def a_star(start: Coord, goal: Coord) -> List[Coord]:
 
     if start == goal:
         return [start]
+
+    if is_blocked(start) or is_blocked(goal):
+        return []
 
     open_set: List[Tuple[float, float, Coord]] = []
     heappush(open_set, (_heuristic(start, goal), 0.0, start))
@@ -75,5 +101,9 @@ def a_star(start: Coord, goal: Coord) -> List[Coord]:
     return []
 
 
-__all__ = ["a_star"]
-
+__all__ = [
+    "a_star",
+    "set_obstacles",
+    "clear_obstacles",
+    "is_blocked",
+]

--- a/tests/test_systems_movement.py
+++ b/tests/test_systems_movement.py
@@ -7,7 +7,11 @@ into a single, conflict-free test module.
 
 # ---------- Path-finding -----------------------------------------------------
 
-from agent_world.systems.movement.pathfinding import a_star
+from agent_world.systems.movement.pathfinding import (
+    a_star,
+    set_obstacles,
+    clear_obstacles,
+)
 
 
 def _manhattan(a: tuple[int, int], b: tuple[int, int]) -> int:
@@ -33,6 +37,14 @@ def test_a_star_diagonal():
 def test_a_star_same_start_goal():
     start = (1, 2)
     assert a_star(start, start) == [start]
+
+
+def test_a_star_with_obstacle():
+    set_obstacles({(1, 0)})
+    path = a_star((0, 0), (2, 0))
+    clear_obstacles()
+    assert path[0] == (0, 0) and path[-1] == (2, 0)
+    assert (1, 0) not in path
 
 
 # ---------- Movement / Velocity ---------------------------------------------
@@ -71,3 +83,25 @@ def test_movement_updates_position_and_index():
     assert (pos.x, pos.y) == (1, 1)
     assert world.spatial_index.query_radius((1, 1), 0) == [e]
     assert world.spatial_index.query_radius((0, 0), 0) == []
+
+
+def test_movement_blocked_by_obstacle():
+    world = World((3, 3))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.spatial_index = SpatialGrid(cell_size=1)
+
+    movement = MovementSystem(world)
+    e = world.entity_manager.create_entity()
+    world.component_manager.add_component(e, Position(0, 0))
+    world.component_manager.add_component(e, Velocity(1, 0))
+    world.spatial_index.insert(e, (0, 0))
+
+    set_obstacles({(1, 0)})
+
+    movement.update()
+
+    pos = world.component_manager.get_component(e, Position)
+    assert (pos.x, pos.y) == (0, 0)
+    assert world.spatial_index.query_radius((0, 0), 0) == [e]
+    clear_obstacles()


### PR DESCRIPTION
## Summary
- add an obstacle grid to movement/pathfinding
- block movement when destination tile is blocked or outside bounds
- update A* to skip blocked tiles and handle invalid start/goal
- extend movement and pathfinding tests

## Testing
- `pytest -q`