### PR TITLE
TASK 9-A-1: implement short-term memory

### DIFF
--- a/agent_world/ai/memory.py
+++ b/agent_world/ai/memory.py
@@ -1,0 +1,59 @@
+"""Lightweight per-agent short-term memory store."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, List
+
+
+@dataclass
+class MemoryEntry:
+    """Single memory snippet and its naive embedding."""
+
+    text: str
+    vector: List[float]
+
+
+def _embed(text: str) -> List[float]:
+    """Return a tiny embedding for ``text``.
+
+    The implementation is intentionally simple and deterministic to keep
+    dependencies minimal. It just maps characters to an averaged value.
+    """
+
+    if not text:
+        return [0.0]
+    total = sum(ord(ch) for ch in text)
+    return [total / len(text)]
+
+
+class ShortTermMemory:
+    """Ring-buffer memory store keyed by ``agent_id``."""
+
+    def __init__(self, capacity: int = 64) -> None:
+        self.capacity = capacity
+        self._store: Dict[int, Deque[MemoryEntry]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def store(self, agent_id: int, snippet: str) -> None:
+        """Insert ``snippet`` for ``agent_id``, pruning oldest if needed."""
+
+        ring = self._store.setdefault(agent_id, deque(maxlen=self.capacity))
+        entry = MemoryEntry(snippet, _embed(snippet))
+        ring.append(entry)
+
+    def retrieve(self, agent_id: int, k: int) -> List[str]:
+        """Return up to ``k`` most recent snippets for ``agent_id``."""
+
+        ring = self._store.get(agent_id)
+        if not ring:
+            return []
+        k = max(0, k)
+        entries = list(ring)[-k:][::-1]
+        return [entry.text for entry in entries]
+
+
+__all__ = ["ShortTermMemory", "MemoryEntry"]

--- a/tests/test_ai_memory.py
+++ b/tests/test_ai_memory.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agent_world.ai.memory import ShortTermMemory
+
+
+def test_store_and_retrieve_order():
+    mem = ShortTermMemory(capacity=3)
+    mem.store(1, "a")
+    mem.store(1, "b")
+    mem.store(1, "c")
+    assert mem.retrieve(1, 2) == ["c", "b"]
+
+
+def test_prune_on_overflow():
+    mem = ShortTermMemory(capacity=2)
+    mem.store(1, "a")
+    mem.store(1, "b")
+    mem.store(1, "c")
+    assert mem.retrieve(1, 3) == ["c", "b"]
+
+
+def test_isolation_between_agents():
+    mem = ShortTermMemory(capacity=5)
+    mem.store(1, "a1")
+    mem.store(2, "b1")
+    mem.store(1, "a2")
+    assert mem.retrieve(1, 2) == ["a2", "a1"]
+    assert mem.retrieve(2, 1) == ["b1"]


### PR DESCRIPTION
## Summary
- add `ShortTermMemory` ring buffer in `ai.memory`
- track snippets per-agent and prune on overflow
- expose retrieval for most recent k snippets
- cover memory behaviour with unit tests

## Testing
- `pytest -q`