### PR TITLE
TASK 13-D-1: implement MeleeStrike ability

### DIFF
--- a/agent_world/abilities/builtin/melee.py
+++ b/agent_world/abilities/builtin/melee.py
@@ -1,1 +1,68 @@
-# Placeholder
+from __future__ import annotations
+
+"""Built-in melee attack ability."""
+
+from typing import Any, Optional
+
+from agent_world.abilities.base import Ability
+from agent_world.core.components.position import Position
+from agent_world.core.components.health import Health
+from agent_world.systems.combat.combat_system import CombatSystem
+
+
+class MeleeStrike(Ability):
+    """Basic melee attack targeting the first enemy in range."""
+
+    def __init__(self) -> None:
+        self.target: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Ability interface
+    # ------------------------------------------------------------------
+    @property
+    def energy_cost(self) -> int:
+        return 0
+
+    @property
+    def cooldown(self) -> int:
+        return 1
+
+    def can_use(self, caster_id: int, world: Any) -> bool:
+        """Return ``True`` if any target is within melee range."""
+
+        if (
+            getattr(world, "entity_manager", None) is None
+            or getattr(world, "component_manager", None) is None
+        ):
+            return False
+
+        em = world.entity_manager
+        cm = world.component_manager
+        pos = cm.get_component(caster_id, Position)
+        if pos is None:
+            return False
+
+        for ent in em.all_entities.keys():
+            if ent == caster_id:
+                continue
+            tpos = cm.get_component(ent, Position)
+            hp = cm.get_component(ent, Health)
+            if tpos is None or hp is None or hp.cur <= 0:
+                continue
+            if CombatSystem._in_melee_range(pos, tpos):
+                self.target = ent
+                return True
+        return False
+
+    def execute(self, caster_id: int, world: Any) -> None:
+        """Perform a melee strike against the selected target."""
+
+        if self.target is None:
+            return
+
+        combat = CombatSystem(world)
+        combat.attack(caster_id, self.target)
+        self.target = None
+
+
+__all__ = ["MeleeStrike"]

--- a/tests/test_builtin_melee.py
+++ b/tests/test_builtin_melee.py
@@ -1,0 +1,31 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.components.position import Position
+from agent_world.core.components.health import Health
+from agent_world.systems.ability.ability_system import AbilitySystem
+
+
+def test_melee_strike_attacks_and_cooldown():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+
+    attacker = world.entity_manager.create_entity()
+    target = world.entity_manager.create_entity()
+
+    cm = world.component_manager
+    cm.add_component(attacker, Position(0, 0))
+    cm.add_component(target, Position(1, 0))
+    cm.add_component(target, Health(cur=20, max=20))
+
+    system = AbilitySystem(world)
+    assert system.use("MeleeStrike", attacker)
+    hp = cm.get_component(target, Health)
+    assert hp.cur == 10
+
+    assert not system.use("MeleeStrike", attacker)
+    system.update()
+    assert system.use("MeleeStrike", attacker)
+    hp = cm.get_component(target, Health)
+    assert hp.cur == 0


### PR DESCRIPTION
## Summary
- implement `MeleeStrike` builtin ability
- load it through `AbilitySystem` and attack nearby targets
- add unit test covering attack behaviour and cooldown

## Testing
- `pytest -q`