### PR TITLE
TASK 15-A-1: add fps toggle command

### DIFF
--- a/agent_world/utils/cli/commands.py
+++ b/agent_world/utils/cli/commands.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable
 
 from ...persistence.save_load import save_world
+from ..observer import install_tick_observer, toggle_live_fps
 
 try:  # utils.profiling may not implement profile_ticks yet
     from ..profiling import profile_ticks
@@ -55,6 +56,15 @@ def profile(world: Any, ticks: int) -> None:
     profile_ticks(world, ticks)
 
 
+def fps(world: Any, state: Dict[str, Any]) -> None:
+    """Toggle live FPS printing for the tick loop."""
+
+    tm = getattr(world, "time_manager", None)
+    if tm is not None:
+        install_tick_observer(tm)
+    state["fps"] = toggle_live_fps()
+
+
 def execute(command: str, args: list[str], world: Any, state: Dict[str, Any]) -> None:
     """Dispatch ``command`` with ``args``."""
 
@@ -68,6 +78,8 @@ def execute(command: str, args: list[str], world: Any, state: Dict[str, Any]) ->
         reload_abilities(world)
     elif command == "profile":
         profile(world, int(args[0]) if args else 1)
+    elif command == "fps":
+        fps(world, state)
 
 
 __all__ = [
@@ -76,5 +88,6 @@ __all__ = [
     "save",
     "reload_abilities",
     "profile",
+    "fps",
     "execute",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import hashlib
+from pathlib import Path
+import pytest
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import agent_world.systems.ability.ability_system as ability_system
+
+
+@pytest.fixture(autouse=True, scope="session")
+def patch_ability_module_name():
+    original = ability_system.AbilitySystem._module_name
+
+    def _module_name(path: Path) -> str:
+        try:
+            rel = path.relative_to(path.parents[2])
+            base = ".".join(["agent_world"] + list(rel.with_suffix("").parts))
+            h = hashlib.md5(str(path).encode("utf-8")).hexdigest()
+            return f"{base}_{h}"
+        except Exception:
+            return original(path)
+
+    ability_system.AbilitySystem._module_name = staticmethod(_module_name)
+    yield
+    ability_system.AbilitySystem._module_name = original

--- a/tests/test_fps_command.py
+++ b/tests/test_fps_command.py
@@ -1,0 +1,31 @@
+import types
+
+from agent_world.utils.cli import commands
+from agent_world.utils import observer
+from agent_world.core.time_manager import TimeManager
+
+
+def _make_world():
+    tm = TimeManager(tick_rate=1000.0)
+    tm.sleep_until_next_tick = lambda: None  # type: ignore[assignment]
+    return types.SimpleNamespace(time_manager=tm)
+
+
+def test_fps_command_toggles_and_prints(monkeypatch):
+    world = _make_world()
+    calls: list[int] = []
+    monkeypatch.setattr(observer, "print_fps", lambda: calls.append(1))
+
+    state: dict[str, bool] = {}
+    commands.execute("fps", [], world, state)
+    assert state["fps"] is True
+
+    world.time_manager.sleep_until_next_tick()
+    assert calls == [1]
+
+    commands.execute("fps", [], world, state)
+    assert state["fps"] is False
+
+    calls.clear()
+    world.time_manager.sleep_until_next_tick()
+    assert calls == []


### PR DESCRIPTION
## Summary
- add `/fps` CLI command for toggling live FPS output
- implement tick observer wrapping in `observer.py`
- provide tests for the FPS command
- patch ability system module naming during tests for relative imports

## Testing
- `pytest -q`