### PR TITLE
TASK 17-B-1: add SpatialGrid bootstrap and indexed pickup

### DIFF
--- a/agent_world/systems/interaction/pickup.py
+++ b/agent_world/systems/interaction/pickup.py
@@ -29,11 +29,16 @@ class PickupSystem:
     def update(self) -> None:
         """Transfer items found at the same position into inventories."""
 
-        if self.world.entity_manager is None or self.world.component_manager is None:
+        if (
+            self.world.entity_manager is None
+            or self.world.component_manager is None
+            or self.world.spatial_index is None
+        ):
             return
 
         em = self.world.entity_manager
         cm = self.world.component_manager
+        index = self.world.spatial_index
 
         # Iterate over actors that can carry items
         for entity_id in list(em.all_entities.keys()):
@@ -43,11 +48,8 @@ class PickupSystem:
                 continue
 
             # Look for items occupying the same position
-            for other_id in list(em.all_entities.keys()):
+            for other_id in index.query_radius((pos.x, pos.y), 0):
                 if other_id == entity_id:
-                    continue
-                other_pos = cm.get_component(other_id, Position)
-                if other_pos is None or (other_pos.x, other_pos.y) != (pos.x, pos.y):
                     continue
 
                 tag = cm.get_component(other_id, Tag)
@@ -68,3 +70,4 @@ class PickupSystem:
                 em.destroy_entity(other_id)
                 cm.remove_component(other_id, Position)
                 cm.remove_component(other_id, Tag)
+                index.remove(other_id)

--- a/tests/test_systems_interaction.py
+++ b/tests/test_systems_interaction.py
@@ -3,6 +3,7 @@ from agent_world.core.entity_manager import EntityManager
 from agent_world.core.component_manager import ComponentManager
 from agent_world.core.components.position import Position
 from agent_world.core.components.inventory import Inventory
+from agent_world.core.spatial.spatial_index import SpatialGrid
 from agent_world.systems.interaction.pickup import PickupSystem, Tag
 from agent_world.systems.interaction.trading import TradingSystem
 from agent_world.systems.interaction.stealing import StealingSystem, Relationship
@@ -12,6 +13,7 @@ def test_pickup_moves_item_to_inventory():
     world = World((5, 5))
     world.entity_manager = EntityManager()
     world.component_manager = ComponentManager()
+    world.spatial_index = SpatialGrid(cell_size=1)
 
     player = world.entity_manager.create_entity()
     item = world.entity_manager.create_entity()
@@ -21,6 +23,7 @@ def test_pickup_moves_item_to_inventory():
 
     world.component_manager.add_component(item, Position(1, 1))
     world.component_manager.add_component(item, Tag("item"))
+    world.spatial_index.insert_many([(player, (1, 1)), (item, (1, 1))])
 
     system = PickupSystem(world)
     system.update()
@@ -34,6 +37,7 @@ def test_pickup_respects_capacity():
     world = World((5, 5))
     world.entity_manager = EntityManager()
     world.component_manager = ComponentManager()
+    world.spatial_index = SpatialGrid(cell_size=1)
 
     player = world.entity_manager.create_entity()
     item1 = world.entity_manager.create_entity()
@@ -47,6 +51,13 @@ def test_pickup_respects_capacity():
 
     world.component_manager.add_component(item2, Position(0, 0))
     world.component_manager.add_component(item2, Tag("item"))
+    world.spatial_index.insert_many(
+        [
+            (player, (0, 0)),
+            (item1, (0, 0)),
+            (item2, (0, 0)),
+        ]
+    )
 
     system = PickupSystem(world)
     system.update()


### PR DESCRIPTION
## Summary
- initialize spatial grid in `bootstrap`
- restore spatial index when loading a saved world
- use the grid in `PickupSystem`
- adapt interaction tests to use the spatial grid

## Testing
- `pytest -q`