### PR TITLE
TASK 18-A-2: support custom ability stub code

### DIFF
--- a/agent_world/ai/angel/generator.py
+++ b/agent_world/ai/angel/generator.py
@@ -20,7 +20,7 @@ def _class_name(slug: str) -> str:
     return "".join(part.capitalize() for part in slug.split("_")) or "GeneratedAbility"
 
 
-def generate_ability(desc: str) -> Path:
+def generate_ability(desc: str, *, stub_code: str | None = None) -> Path:
     """Create a basic ability module under :mod:`abilities.generated`.
 
     Parameters
@@ -45,6 +45,11 @@ def generate_ability(desc: str) -> Path:
         path = GENERATED_DIR / filename
         counter += 1
 
+    body = "pass"
+    if stub_code:
+        lines = stub_code.strip().splitlines()
+        body = "\n".join("        " + ln.rstrip() for ln in lines) or "pass"
+
     template = f'''"""Generated ability scaffold.
 
 Description:
@@ -61,7 +66,7 @@ class {class_name}(Ability):
         return True
 
     def execute(self, user, world) -> None:
-        pass
+{body}
 
     @property
     def energy_cost(self) -> int:

--- a/tests/test_angel_generator.py
+++ b/tests/test_angel_generator.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from agent_world.ai.angel import generator
+from agent_world.systems.ability.ability_system import AbilitySystem
+
+
+def test_generate_ability_with_stub(monkeypatch, tmp_path: Path) -> None:
+    gen_dir = tmp_path / "abilities" / "generated"
+    monkeypatch.setattr(generator, "GENERATED_DIR", gen_dir)
+
+    world: dict = {}
+    system = AbilitySystem(world, search_dirs=[gen_dir])
+
+    path = generator.generate_ability(
+        "Test Ability", stub_code="world['flag'] = True"
+    )
+    assert path.exists()
+
+    system.update()
+    ability_name = generator._class_name(generator._slugify("Test Ability"))
+    assert ability_name in system.abilities
+
+    assert system.use(ability_name, 1)
+    assert world.get("flag") is True


### PR DESCRIPTION
## Summary
- extend the angel generator to accept optional `stub_code`
- include stub text inside generated `execute()`
- verify hot-reload of generated ability with custom body

## Testing
- `pytest -q`