### PR TITLE
TASK 19-A-2: implement event log rotation

### DIFF
--- a/tests/test_persistence_event_log.py
+++ b/tests/test_persistence_event_log.py
@@ -5,6 +5,9 @@ from pathlib import Path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agent_world.persistence.event_log import EventLog, append_event, iter_events
+import agent_world.persistence.event_log as evlog
+import gzip
+import json
 
 
 def test_append_and_iter_events(tmp_path: Path) -> None:
@@ -32,3 +35,18 @@ def test_event_log_class(tmp_path: Path) -> None:
 def test_iter_events_missing_file(tmp_path: Path) -> None:
     path = tmp_path / "missing.jsonl"
     assert list(iter_events(path)) == []
+
+
+def test_log_rotation(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setattr(evlog, "_log_retention_bytes", lambda: 100)
+    for i in range(3):
+        append_event(path, i, "test", {"n": i})
+
+    gz_files = [p for p in tmp_path.iterdir() if p.suffix == ".gz"]
+    assert len(gz_files) == 1
+    with gzip.open(gz_files[0], "rt", encoding="utf-8") as fh:
+        rotated = [json.loads(l) for l in fh if l.strip()]
+    assert [e["tick"] for e in rotated] == [0, 1]
+    remaining = list(iter_events(path))
+    assert len(remaining) == 1 and remaining[0]["tick"] == 2


### PR DESCRIPTION
## Summary
- rotate event logs based on config `cache.log_retention_mb`
- compress rotated logs as `*.jsonl.gz`
- test event log rotation behaviour

## Testing
- `pytest -q`