### PR TITLE
TASK 20-A-2: implement renderer draw and fps overlay

### DIFF
--- a/agent_world/gui/renderer.py
+++ b/agent_world/gui/renderer.py
@@ -1,8 +1,14 @@
-"""Stub renderer for GUI integration."""
+"""Renderer for drawing entities to a :class:`Window`."""
 
 from __future__ import annotations
 
 from typing import Any
+
+import pygame
+
+from ..core.components.position import Position
+from ..utils.asset_generation import sprite_gen
+from ..utils import observer
 
 from .window import Window
 
@@ -12,12 +18,50 @@ class Renderer:
 
     def __init__(self, window: Window | None = None) -> None:
         self.window = window if window is not None else Window()
+        self.center = [0.0, 0.0]
+        self.zoom = 1.0
 
     def update(self, world: Any) -> None:
-        """Render the current state of ``world`` (no-op)."""
+        """Render the current state of ``world``."""
 
-        # No-op stub implementation
-        return None
+        em = getattr(world, "entity_manager", None)
+        cm = getattr(world, "component_manager", None)
+        if em is None or cm is None:
+            return
+
+        for ev in pygame.event.get():
+            if ev.type == pygame.KEYDOWN:
+                if ev.key == pygame.K_LEFT:
+                    self.center[0] -= 1
+                elif ev.key == pygame.K_RIGHT:
+                    self.center[0] += 1
+                elif ev.key == pygame.K_UP:
+                    self.center[1] -= 1
+                elif ev.key == pygame.K_DOWN:
+                    self.center[1] += 1
+            elif ev.type == pygame.MOUSEWHEEL:
+                self.zoom *= 1.0 + ev.y * 0.1
+                self.zoom = max(self.zoom, 0.1)
+
+        tile_w, tile_h = sprite_gen.SPRITE_SIZE
+
+        for entity_id in list(em.all_entities.keys()):
+            pos = cm.get_component(entity_id, Position)
+            if pos is None:
+                continue
+            sprite = sprite_gen.get_sprite(entity_id)
+            x = int((pos.x - self.center[0]) * tile_w * self.zoom)
+            y = int((pos.y - self.center[1]) * tile_h * self.zoom)
+            self.window.draw_sprite(entity_id, x, y, sprite)
+
+        if observer._tick_durations:
+            avg = sum(observer._tick_durations) / len(observer._tick_durations)
+            fps = 1.0 / avg if avg > 0 else float("inf")
+            text = f"{fps:.1f} FPS"
+        else:
+            text = "FPS: --"
+        self.window.draw_text(text, 5, 5)
+
 
 
 __all__ = ["Renderer"]

--- a/agent_world/utils/observer.py
+++ b/agent_world/utils/observer.py
@@ -47,6 +47,15 @@ def print_fps() -> None:
     print(msg)
 
 
+def average_fps() -> float:
+    """Return the average FPS based on ``_tick_durations``."""
+
+    if not _tick_durations:
+        return 0.0
+    avg = sum(_tick_durations) / len(_tick_durations)
+    return 1.0 / avg if avg > 0 else float("inf")
+
+
 def toggle_live_fps() -> bool:
     """Toggle live FPS printing. Returns ``True`` if enabled after toggle."""
 
@@ -127,6 +136,7 @@ __all__ = [
     "warn_missing_managers",
     "log_event",
     "dump_state",
+    "average_fps",
     "_tick_durations",
     "_events",
 ]

--- a/tests/test_gui_renderer.py
+++ b/tests/test_gui_renderer.py
@@ -1,0 +1,60 @@
+from PIL import Image
+import pygame
+
+from agent_world.gui.renderer import Renderer
+from agent_world.gui.window import Window
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.components.position import Position
+from agent_world.utils.asset_generation import sprite_gen
+
+
+class DummyWindow(Window):
+    def __init__(self) -> None:
+        self.sprites = []
+        self.text = []
+
+    def draw_sprite(self, entity_id: int, x: int, y: int, pil_image: Image.Image) -> None:
+        self.sprites.append((entity_id, x, y))
+
+    def draw_text(self, text: str, x: int, y: int, colour=(255, 255, 255)) -> None:
+        self.text.append(text)
+
+    def refresh(self) -> None:  # pragma: no cover - not used
+        pass
+
+
+def _make_world() -> World:
+    w = World((10, 10))
+    w.entity_manager = EntityManager()
+    w.component_manager = ComponentManager()
+    eid = w.entity_manager.create_entity()
+    w.component_manager.add_component(eid, Position(2, 3))
+    return w
+
+
+def test_renderer_draws_entities(monkeypatch):
+    world = _make_world()
+    window = DummyWindow()
+    renderer = Renderer(window)
+    monkeypatch.setattr(sprite_gen, "get_sprite", lambda eid: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(pygame.event, "get", lambda: [])
+    renderer.update(world)
+    assert len(window.sprites) == 1
+
+
+def test_renderer_input_pan_zoom(monkeypatch):
+    world = _make_world()
+    window = DummyWindow()
+    renderer = Renderer(window)
+    events = [
+        pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHT),
+        pygame.event.Event(pygame.MOUSEWHEEL, y=1),
+    ]
+    monkeypatch.setattr(sprite_gen, "get_sprite", lambda eid: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(pygame.event, "get", lambda: events)
+    renderer.update(world)
+    assert renderer.center[0] > 0
+    assert renderer.zoom > 1.0
+

--- a/tests/test_utils_observer.py
+++ b/tests/test_utils_observer.py
@@ -21,3 +21,9 @@ def test_log_event_helpers():
     observer._events.clear()
     observer.log_event("move_blocked", {"entity": 2, "pos": (1, 0)})
     assert observer._events[-1] == {"type": "move_blocked", "entity": 2, "pos": (1, 0)}
+
+
+def test_average_fps():
+    observer._tick_durations.clear()
+    observer._tick_durations.extend([0.1, 0.1])
+    assert observer.average_fps() == 10.0


### PR DESCRIPTION
## Summary
- extend renderer with camera controls and FPS overlay
- expose `average_fps` helper in observer
- add unit tests for new renderer behaviour and FPS calculation

## Testing
- `pytest -q`