### PR TITLE
TASK 20-B-2: add outline sprite variants

### DIFF
--- a/agent_world/utils/asset_generation/sprite_gen.py
+++ b/agent_world/utils/asset_generation/sprite_gen.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import random
-from typing import Dict
+from typing import Tuple, Optional
 from collections import OrderedDict
 
 from PIL import Image, ImageDraw, ImageFont
@@ -17,7 +17,9 @@ ASSETS_DIR.mkdir(exist_ok=True)
 # Maximum sprites kept in RAM before older entries are evicted.
 MAX_SPRITES = 10000
 
-_SPRITE_CACHE: "OrderedDict[int, Image.Image]" = OrderedDict()
+CacheKey = Tuple[int, Optional[Tuple[int, int, int]]]
+
+_SPRITE_CACHE: "OrderedDict[CacheKey, Image.Image]" = OrderedDict()
 
 
 def _color_from_id(entity_id: int) -> tuple[int, int, int]:
@@ -27,8 +29,18 @@ def _color_from_id(entity_id: int) -> tuple[int, int, int]:
     return rnd.randint(0, 255), rnd.randint(0, 255), rnd.randint(0, 255)
 
 
-def generate_sprite(entity_id: int) -> Image.Image:
-    """Create a 32×32 ``Image`` for ``entity_id``."""
+def generate_sprite(
+    entity_id: int, outline_colour: Optional[Tuple[int, int, int]] = None
+) -> Image.Image:
+    """Create a 32×32 ``Image`` for ``entity_id``.
+
+    Parameters
+    ----------
+    entity_id:
+        Unique identifier used to deterministically generate sprite colour.
+    outline_colour:
+        Optional RGB tuple used to draw a border around the sprite.
+    """
 
     img = Image.new("RGB", SPRITE_SIZE, _color_from_id(entity_id))
     draw = ImageDraw.Draw(img)
@@ -43,27 +55,42 @@ def generate_sprite(entity_id: int) -> Image.Image:
         fill="white",
         font=font,
     )
+    if outline_colour is not None:
+        draw.rectangle(
+            [(0, 0), (SPRITE_SIZE[0] - 1, SPRITE_SIZE[1] - 1)],
+            outline=outline_colour,
+            width=2,
+        )
     return img
 
 
-def get_sprite(entity_id: int) -> Image.Image:
-    """Return cached sprite image for ``entity_id``."""
+def get_sprite(
+    entity_id: int, outline_colour: Optional[Tuple[int, int, int]] = None
+) -> Image.Image:
+    """Return cached sprite image for ``entity_id``.
 
-    sprite = _SPRITE_CACHE.get(entity_id)
+    ``outline_colour`` specifies an optional border. Variants with different
+    outlines are cached separately.
+    """
+
+    cache_key: CacheKey = (entity_id, outline_colour)
+    sprite = _SPRITE_CACHE.get(cache_key)
     if sprite is not None:
-        # Refresh order on access
-        _SPRITE_CACHE.move_to_end(entity_id)
+        _SPRITE_CACHE.move_to_end(cache_key)
         return sprite
 
-    path = ASSETS_DIR / f"{entity_id}.png"
-    if path.exists():
-        sprite = Image.open(path)
+    if outline_colour is None:
+        path = ASSETS_DIR / f"{entity_id}.png"
+        if path.exists():
+            sprite = Image.open(path)
+        else:
+            sprite = generate_sprite(entity_id)
+            sprite.save(path, format="PNG")
     else:
-        sprite = generate_sprite(entity_id)
-        sprite.save(path, format="PNG")
+        sprite = generate_sprite(entity_id, outline_colour)
 
-    _SPRITE_CACHE[entity_id] = sprite
-    _SPRITE_CACHE.move_to_end(entity_id)
+    _SPRITE_CACHE[cache_key] = sprite
+    _SPRITE_CACHE.move_to_end(cache_key)
     if len(_SPRITE_CACHE) > MAX_SPRITES:
         # Pop least-recently-used entry
         _SPRITE_CACHE.popitem(last=False)

--- a/tests/test_asset_generation.py
+++ b/tests/test_asset_generation.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from PIL import Image
@@ -31,6 +30,11 @@ def test_get_sprite_generates_and_caches(tmp_path: Path, monkeypatch) -> None:
     img2 = sprite_gen.get_sprite(7)
     assert img1 is img2
 
+    outline = (255, 0, 0)
+    img3 = sprite_gen.get_sprite(7, outline_colour=outline)
+    assert isinstance(img3, Image.Image)
+    assert img3 is sprite_gen.get_sprite(7, outline_colour=outline)
+
 
 def test_sprite_cache_eviction(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(sprite_gen, "ASSETS_DIR", tmp_path)
@@ -44,6 +48,6 @@ def test_sprite_cache_eviction(tmp_path: Path, monkeypatch) -> None:
     sprite_gen.get_sprite(3)
 
     assert len(sprite_gen._SPRITE_CACHE) == 2
-    assert 1 in sprite_gen._SPRITE_CACHE
-    assert 3 in sprite_gen._SPRITE_CACHE
-    assert 2 not in sprite_gen._SPRITE_CACHE
+    assert (1, None) in sprite_gen._SPRITE_CACHE
+    assert (3, None) in sprite_gen._SPRITE_CACHE
+    assert (2, None) not in sprite_gen._SPRITE_CACHE


### PR DESCRIPTION
## Summary
- support `outline_colour` argument in `generate_sprite`
- cache outlined sprite variants independently in `get_sprite`
- update tests for new signature and cache behaviour

## Testing
- `pytest -q`