### PR TITLE
TASK 21-A-2: implement async reasoning cooldown

### DIFF
--- a/agent_world/systems/ai/ai_reasoning_system.py
+++ b/agent_world/systems/ai/ai_reasoning_system.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Tuple
 
+COOLDOWN_TICKS = 10
+
 from ...core.components.ai_state import AIState
 from ...ai.llm.prompt_builder import build_prompt
 from ...ai.llm.llm_manager import LLMManager
@@ -30,29 +32,58 @@ class AIReasoningSystem:
     # Update
     # ------------------------------------------------------------------
     def update(self, tick: int) -> None:
-        """Build prompts for agents and enqueue LLM completions."""
+        """Handle pending and new LLM prompts for all agents."""
 
-        if self.world.entity_manager is None or self.world.component_manager is None:
+        if (
+            self.world.entity_manager is None
+            or self.world.component_manager is None
+            or self.world.time_manager is None
+        ):
             return
 
         em = self.world.entity_manager
         cm = self.world.component_manager
+        tm = self.world.time_manager
 
         for entity_id in list(em.all_entities.keys()):
             state = cm.get_component(entity_id, AIState)
             if state is None:
                 continue
 
-            prompt = build_prompt(entity_id, self.world)
-            action_str = self.llm.request(prompt, timeout=0.05)
-            
-            if action_str == "<wait>" and self.behavior_tree:
-                fallback = self.behavior_tree.run(entity_id, self.world)
-                if fallback is not None:
-                    action_str = fallback
-            
-            if action_str and action_str != "<wait>": # Only append if not empty and not <wait>
-                self.action_tuples_list.append((entity_id, action_str))
+            if tm.tick_counter <= state.last_llm_action_tick + COOLDOWN_TICKS:
+                continue
+
+            if state.pending_llm_prompt_id is None:
+                prompt = build_prompt(entity_id, self.world)
+                result = self.llm.request(prompt, self.world)
+
+                if result and result in self.world.async_llm_responses:
+                    state.pending_llm_prompt_id = result
+                    continue
+
+                action_str = result
+                if action_str and action_str != "<wait>":
+                    self.action_tuples_list.append((entity_id, action_str))
+                    state.last_llm_action_tick = tm.tick_counter
+                elif self.behavior_tree is not None:
+                    fallback = self.behavior_tree.run(entity_id, self.world)
+                    if fallback:
+                        self.action_tuples_list.append((entity_id, fallback))
+            else:
+                fut = self.world.async_llm_responses.get(state.pending_llm_prompt_id)
+                if fut is not None and fut.done():
+                    action_str = (
+                        self.world.async_llm_responses.pop(state.pending_llm_prompt_id).result()
+                    )
+                    if action_str and action_str != "<wait>":
+                        self.action_tuples_list.append((entity_id, action_str))
+                        state.last_llm_action_tick = tm.tick_counter
+                    else:
+                        if self.behavior_tree is not None:
+                            fallback = self.behavior_tree.run(entity_id, self.world)
+                            if fallback:
+                                self.action_tuples_list.append((entity_id, fallback))
+                    state.pending_llm_prompt_id = None
 
 
 __all__ = ["AIReasoningSystem"]


### PR DESCRIPTION
## Summary
- use cooldown ticks for LLM reasoning
- store prompt ids and poll async responses

## Testing
- `pytest -q` *(fails: 15 failed, 83 passed)*