### PR TITLE
TASK 21-B-1: add Log and Idle actions

### DIFF
--- a/agent_world/systems/ai/action_execution_system.py
+++ b/agent_world/systems/ai/action_execution_system.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from .actions import ActionQueue, MoveAction, AttackAction
+import logging
+
+from .actions import (
+    ActionQueue,
+    MoveAction,
+    AttackAction,
+    LogAction,
+    IdleAction,
+)
 from ..combat.combat_system import CombatSystem
 from ..movement.movement_system import Velocity
 from ...core.components.force import apply_force
@@ -38,6 +46,12 @@ class ActionExecutionSystem:
                 cm.remove_component(action.actor, Velocity)
             elif isinstance(action, AttackAction):
                 self.combat.attack(action.actor, action.target, tick=tick)
+            elif isinstance(action, LogAction):
+                print(action.message)
+            elif isinstance(action, IdleAction):
+                pass
+            else:
+                logging.warning("Unknown action %r; treating as idle", action)
 
 
 __all__ = ["ActionExecutionSystem"]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -8,6 +8,8 @@ from agent_world.systems.ai.actions import (
     ActionQueue,
     MoveAction,
     AttackAction,
+    LogAction,
+    IdleAction,
 )
 
 
@@ -39,3 +41,11 @@ def test_action_queue_enqueues_valid_actions():
     action = q.pop()
     assert isinstance(action, MoveAction)
     assert (action.dx, action.dy) == (1, 0)
+
+
+def test_parse_log_and_idle_actions() -> None:
+    log = parse_action(3, "LOG hello world")
+    idle = parse_action(4, "IDLE")
+    assert isinstance(log, LogAction) and log.message == "hello world"
+    assert log.actor == 3
+    assert isinstance(idle, IdleAction) and idle.actor == 4

--- a/tests/test_systems_action_execution.py
+++ b/tests/test_systems_action_execution.py
@@ -2,7 +2,14 @@ from agent_world.core.world import World
 from agent_world.core.entity_manager import EntityManager
 from agent_world.core.component_manager import ComponentManager
 from agent_world.systems.ai.actions import ActionQueue
-from agent_world.systems.ai.actions import MoveAction, AttackAction
+import logging
+
+from agent_world.systems.ai.actions import (
+    MoveAction,
+    AttackAction,
+    LogAction,
+    IdleAction,
+)
 from agent_world.systems.ai.action_execution_system import ActionExecutionSystem
 from agent_world.systems.movement.movement_system import Velocity
 from agent_world.core.components.force import Force, apply_force
@@ -59,3 +66,37 @@ def test_action_execution_translates_actions() -> None:
     assert force is not None and (force.dx, force.dy) == (1, 0)
     assert world.component_manager.get_component(attacker, Velocity) is None
     assert combat.calls == [(attacker, target, 5)]
+
+
+def test_log_and_idle_actions(capsys) -> None:
+    world = _make_world()
+    combat = DummyCombat()
+    queue = ActionQueue()
+    actor = world.entity_manager.create_entity()
+
+    queue.enqueue_raw(actor, "LOG test")
+    queue.enqueue_raw(actor, "IDLE")
+
+    system = ActionExecutionSystem(world, queue, combat)
+    system.update(tick=1)
+
+    captured = capsys.readouterr().out
+    assert "test" in captured
+    assert combat.calls == []
+
+
+def test_unknown_action_logs_warning(caplog) -> None:
+    world = _make_world()
+    combat = DummyCombat()
+    queue = ActionQueue()
+
+    class UnknownAction:
+        def __init__(self) -> None:
+            self.actor = 1
+
+    queue._queue.append(UnknownAction())
+
+    system = ActionExecutionSystem(world, queue, combat)
+    with caplog.at_level(logging.WARNING):
+        system.update(tick=1)
+    assert any("Unknown action" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- support `LOG` and `IDLE` commands in action parser
- execute `LogAction` and `IdleAction` in `ActionExecutionSystem`
- warn on unknown actions instead of crashing
- extend tests for new actions and execution handling

## Testing
- `pytest -q tests/test_actions.py tests/test_systems_action_execution.py`
- `python main.py`