### PR TITLE
TASK 1-S-2: add RoleComponent stub

### DIFF
--- a/agent_world/core/components/role.py
+++ b/agent_world/core/components/role.py
@@ -1,0 +1,19 @@
+"""Role component."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class RoleComponent:
+    """Define an entity's role and related behaviour flags."""
+
+    role_name: str
+    can_request_abilities: bool = True
+    uses_llm: bool = True
+    fixed_abilities: List[str] = field(default_factory=list)
+
+
+__all__ = ["RoleComponent"]

--- a/tests/core/test_role_stub.py
+++ b/tests/core/test_role_stub.py
@@ -1,0 +1,29 @@
+import pytest
+
+from agent_world.core.components.role import RoleComponent
+from agent_world.persistence.serializer import serialize, deserialize
+
+
+def test_role_component_defaults_roundtrip():
+    comp = RoleComponent("farmer")
+    restored = deserialize(serialize(comp))
+    assert isinstance(restored, RoleComponent)
+    assert restored.role_name == "farmer"
+    assert restored.can_request_abilities is True
+    assert restored.uses_llm is True
+    assert restored.fixed_abilities == []
+
+
+def test_role_component_custom_roundtrip():
+    original = RoleComponent(
+        role_name="wizard",
+        can_request_abilities=False,
+        uses_llm=False,
+        fixed_abilities=["Fireball", "Teleport"],
+    )
+    restored = deserialize(serialize(original))
+    assert isinstance(restored, RoleComponent)
+    assert restored.role_name == original.role_name
+    assert restored.can_request_abilities == original.can_request_abilities
+    assert restored.uses_llm == original.uses_llm
+    assert restored.fixed_abilities == original.fixed_abilities


### PR DESCRIPTION
## Summary
- implement `RoleComponent` dataclass in components
- serialize/deserialize round‑trip tests

## Testing
- `PYTHONPATH=. pytest tests/core/test_role_stub.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*