### PR TITLE
TASK 1-S-1: add KnownAbilitiesComponent stub

### DIFF
--- a/agent_world/core/components/__init__.py
+++ b/agent_world/core/components/__init__.py
@@ -1,1 +1,5 @@
 """components package."""
+
+from .known_abilities import KnownAbilitiesComponent
+
+__all__ = ["KnownAbilitiesComponent"]

--- a/agent_world/core/components/known_abilities.py
+++ b/agent_world/core/components/known_abilities.py
@@ -1,0 +1,15 @@
+"""Track ability class names already granted to an entity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class KnownAbilitiesComponent:
+    """Simple list of ability class names available to an entity."""
+
+    known_class_names: list[str] = field(default_factory=list)
+
+
+__all__ = ["KnownAbilitiesComponent"]

--- a/agent_world/persistence/serializer.py
+++ b/agent_world/persistence/serializer.py
@@ -6,6 +6,9 @@ import importlib
 from dataclasses import asdict, is_dataclass
 from typing import Any, Dict
 
+# Import components so their classes are discoverable during deserialisation.
+from ..core.components.known_abilities import KnownAbilitiesComponent  # noqa: F401
+
 
 def _class_path(obj: Any) -> str:
     """Return the fully-qualified class path for ``obj``."""

--- a/tests/core/test_known_abilities_stub.py
+++ b/tests/core/test_known_abilities_stub.py
@@ -1,0 +1,6 @@
+from agent_world.core.components.known_abilities import KnownAbilitiesComponent
+
+
+def test_default_known_abilities_state():
+    comp = KnownAbilitiesComponent()
+    assert comp.known_class_names == []


### PR DESCRIPTION
## Summary
- create `KnownAbilitiesComponent` dataclass
- export component from `components` package and serializer stub
- add a simple test verifying default state

## Testing
- `PYTHONPATH=$(pwd) pytest tests/core/test_known_abilities_stub.py -q`
- `PYTHONPATH=$(pwd) pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*