### PR TITLE
Implement world pause flag and AI state rethink field

### DIFF
--- a/agent_world/core/components/ai_state.py
+++ b/agent_world/core/components/ai_state.py
@@ -16,3 +16,4 @@ class AIState:
     last_llm_action_tick: int = -1
     last_bt_direction_index: int = 0 # Index for cycling N, E, S, W
     last_bt_move_failed: bool = False # Flag if last BT move resulted in no actual movement (e.g. collision)
+    needs_immediate_rethink: bool = False

--- a/agent_world/core/world.py
+++ b/agent_world/core/world.py
@@ -42,6 +42,7 @@ class World:
 
         # For GUI state
         self.gui_enabled: bool = False
+        self.paused_for_angel: bool = False
 
         # Pre-computed glyph/colour data for resource types
         self._resource_defs = {

--- a/tests/core/test_world_pause_flag.py
+++ b/tests/core/test_world_pause_flag.py
@@ -1,0 +1,18 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from agent_world.core.world import World
+from agent_world.core.components.ai_state import AIState
+
+
+def test_world_paused_for_angel_default():
+    world = World((5, 5))
+    assert world.paused_for_angel is False
+
+
+def test_ai_state_needs_immediate_rethink_default():
+    state = AIState(personality="tester")
+    assert state.needs_immediate_rethink is False


### PR DESCRIPTION
## Summary
- allow the world to be paused for Angel processing
- extend AI state dataclass with immediate rethink flag
- add tests confirming defaults

## Testing
- `pytest -q tests/core/test_world_pause_flag.py`