### PR TITLE
Task 1-A-1: pause-aware main loop

### DIFF
--- a/agent_world/main.py
+++ b/agent_world/main.py
@@ -358,10 +358,14 @@ def main() -> None:
                 elif world.raw_actions_with_actor and world.action_queue is None:
                     print(f"[Tick {tm.tick_counter}] MainLoop: CRITICAL - world.action_queue is None.")
 
-                if world.systems_manager:
-                    world.systems_manager.update(world, tm.tick_counter) # Pass world and tick
+                if not world.paused_for_angel:
+                    if world.systems_manager:
+                        world.systems_manager.update(world, tm.tick_counter) # Pass world and tick
 
-                tm.sleep_until_next_tick() 
+                    tm.sleep_until_next_tick()
+                else:
+                    time.sleep(0.016)
+
                 step_once = False
             else: 
                 if world.gui_enabled and actual_renderer.window and hasattr(actual_renderer.window, '_surface'):

--- a/tests/integration/test_world_pause.py
+++ b/tests/integration/test_world_pause.py
@@ -1,0 +1,34 @@
+import time
+from agent_world.main import bootstrap
+
+
+def test_tick_counter_pauses_when_flag_set():
+    world = bootstrap(config_path="config.yaml")
+    tm = world.time_manager
+
+    # Ensure a fresh tick counter
+    tm.tick_counter = 0
+
+    # Simulate one normal tick
+    if world.systems_manager:
+        world.systems_manager.update(world, tm.tick_counter)
+    tm.sleep_until_next_tick()
+    first_tick = tm.tick_counter
+    assert first_tick == 1
+
+    # Activate pause and attempt another iteration of main loop logic
+    world.paused_for_angel = True
+
+    if world.raw_actions_with_actor and world.action_queue is not None:
+        for actor_id, action_text in world.raw_actions_with_actor:
+            world.action_queue.enqueue_raw(actor_id, action_text)
+        world.raw_actions_with_actor.clear()
+
+    if not world.paused_for_angel:
+        if world.systems_manager:
+            world.systems_manager.update(world, tm.tick_counter)
+        tm.sleep_until_next_tick()
+    else:
+        time.sleep(0.016)
+
+    assert tm.tick_counter == first_tick


### PR DESCRIPTION
## Summary
- support world pause flag in main tick loop
- ensure tick counter frozen when world is paused

## Testing
- `python -m agent_world.main` *(fails: KeyboardInterrupt to exit)*
- `PYTHONPATH=$PWD pytest -q` *(fails: test_agent_requests_generates_and_uses_heal_ability)*