### PR TITLE
TASK 1-S-2: import RoleComponent in serializer

### DIFF
--- a/agent_world/persistence/serializer.py
+++ b/agent_world/persistence/serializer.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 # Import components so their classes are discoverable during deserialisation.
 from ..core.components.known_abilities import KnownAbilitiesComponent  # noqa: F401
+from ..core.components.role import RoleComponent                       # noqa: F401
 
 
 def _class_path(obj: Any) -> str:


### PR DESCRIPTION
## Summary
- keep the serializer symmetrical by importing RoleComponent

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `python -m agent_world.main` *(interrupted with `Ctrl+C`)*