### PR TITLE
TASK 2-A-5: warn when granting ability to unknown agent

### DIFF
--- a/agent_world/ai/angel/system.py
+++ b/agent_world/ai/angel/system.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+import logging
 import re
 
 from . import generator as angel_generator
@@ -20,6 +21,15 @@ class AngelSystem:
         cm = getattr(self.world, "component_manager", None)
         if cm is None:
             return
+
+        em = getattr(self.world, "entity_manager", None)
+        if em is not None and not em.has_entity(agent_id):
+            logging.warning(
+                "AngelSystem: attempted to grant ability to unknown agent_id %s",
+                agent_id,
+            )
+            return
+
         comp = cm.get_component(agent_id, KnownAbilitiesComponent)
         if comp is None:
             comp = KnownAbilitiesComponent()


### PR DESCRIPTION
## Summary
- log a warning if AngelSystem tries to grant an ability to an unknown agent
- keep existing behaviour when component manager is missing

## Testing
- `PYTHONPATH=. pytest -q tests/core tests/systems`