### PR TITLE
Fix AbilitySystem to load vault abilities

### DIFF
--- a/agent_world/systems/ability/ability_system.py
+++ b/agent_world/systems/ability/ability_system.py
@@ -25,12 +25,13 @@ class AbilitySystem:
         base_dir = Path(__file__).resolve().parents[2] / "abilities"
         builtin_dir = base_dir / "builtin"
         generated_dir = base_dir / "generated"
+        vault_dir = base_dir / "vault"
         
         # Ensure generated directory exists
         generated_dir.mkdir(parents=True, exist_ok=True)
 
         self.search_dirs: List[Path] = (
-            list(search_dirs) if search_dirs is not None else [builtin_dir, generated_dir]
+            list(search_dirs) if search_dirs is not None else [builtin_dir, generated_dir, vault_dir]
         )
         logger.info(f"AbilitySystem initialized. Searching for abilities in: {self.search_dirs}")
 

--- a/tests/systems/test_ability_system_vault.py
+++ b/tests/systems/test_ability_system_vault.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from agent_world.core.world import World
+from agent_world.systems.ability.ability_system import AbilitySystem
+
+
+def test_vault_abilities_loaded_by_default():
+    world = World((5, 5))
+    system = AbilitySystem(world)
+    assert "SampleFireball" in system.abilities


### PR DESCRIPTION
## Summary
- include the `abilities/vault` directory when initializing the ability loader
- add a test verifying that `SampleFireball` from the vault is discovered

## Testing
- `PYTHONPATH=$PWD pytest -q tests/systems/test_ability_system_vault.py -q`
- `PYTHONPATH=$PWD pytest -q tests/angel/test_angel_system_stub.py tests/angel/test_angel_vault_and_generation.py::test_vault_hit_returns_existing_ability tests/core/test_known_abilities_stub.py tests/core/test_role_stub.py -q`