### PR TITLE
TASK 3-A-2: bypass cooldown when immediate rethink

### DIFF
--- a/agent_world/systems/ai/ai_reasoning_system.py
+++ b/agent_world/systems/ai/ai_reasoning_system.py
@@ -75,8 +75,18 @@ class AIReasoningSystem:
             if ai_comp is None:
                 continue
 
-            if tm.tick_counter <= ai_comp.last_llm_action_tick + COOLDOWN_TICKS and ai_comp.last_llm_action_tick != -1:
-                continue 
+            bypass_cooldown = False
+            if ai_comp.needs_immediate_rethink:
+                ai_comp.needs_immediate_rethink = False
+                bypass_cooldown = True
+
+            if (
+                not bypass_cooldown
+                and tm.tick_counter
+                <= ai_comp.last_llm_action_tick + COOLDOWN_TICKS
+                and ai_comp.last_llm_action_tick != -1
+            ):
+                continue
 
             final_action_to_take: str | None = None
             llm_attempt_made_or_resolved = False # Track if we interacted with LLM this tick

--- a/tests/systems/test_immediate_rethink.py
+++ b/tests/systems/test_immediate_rethink.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.ai_state import AIState
+from agent_world.systems.ai.ai_reasoning_system import AIReasoningSystem
+
+
+class DummyLLM:
+    mode = "offline"
+
+
+def test_immediate_rethink_bypasses_cooldown():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    world.llm_manager_instance = DummyLLM()
+    world.async_llm_responses = {}
+
+    actions = []
+    system = AIReasoningSystem(world, world.llm_manager_instance, actions)
+
+    agent_id = world.entity_manager.create_entity()
+    state = AIState(personality="tester")
+    world.component_manager.add_component(agent_id, state)
+
+    world.time_manager.tick_counter = 0
+    state.last_llm_action_tick = 0
+    state.needs_immediate_rethink = True
+
+    world.time_manager.tick_counter = 1
+    system.update(1)
+
+    assert state.needs_immediate_rethink is False
+    assert state.last_llm_action_tick == 1
+    assert actions, "Expected an action produced when immediate rethink is set"


### PR DESCRIPTION
## Summary
- skip cooldown when `AIState.needs_immediate_rethink` is set
- add regression test for immediate rethink logic

## Testing
- `PYTHONPATH=. pytest -q tests/core tests/systems`