### PR TITLE
TASK 4-A-1: add roles YAML and test

### DIFF
--- a/agent_world/data/roles.yaml
+++ b/agent_world/data/roles.yaml
@@ -1,0 +1,16 @@
+creature:
+  can_request_abilities: false
+  uses_llm: false
+  fixed_abilities:
+    - MeleeStrike
+merchant:
+  can_request_abilities: false
+  uses_llm: true
+  fixed_abilities: []
+
+guard:
+  can_request_abilities: true
+  uses_llm: false
+  fixed_abilities:
+    - MeleeStrike
+    - ArrowShot

--- a/tests/data/test_roles_yaml.py
+++ b/tests/data/test_roles_yaml.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import yaml
+
+
+def test_roles_yaml_schema():
+    path = Path('agent_world/data/roles.yaml')
+    assert path.is_file(), 'roles.yaml file missing'
+
+    with open(path, 'r', encoding='utf-8') as fh:
+        data = yaml.safe_load(fh)
+
+    assert isinstance(data, dict)
+    # required roles
+    for role in ('creature', 'merchant', 'guard'):
+        assert role in data
+
+    for role_name, cfg in data.items():
+        assert isinstance(cfg, dict)
+        assert set(cfg.keys()) == {
+            'can_request_abilities',
+            'uses_llm',
+            'fixed_abilities',
+        }
+        assert isinstance(cfg['can_request_abilities'], bool)
+        assert isinstance(cfg['uses_llm'], bool)
+        assert isinstance(cfg['fixed_abilities'], list)
+        assert all(isinstance(a, str) for a in cfg['fixed_abilities'])


### PR DESCRIPTION
## Summary
- define default roles in `agent_world/data/roles.yaml`
- validate schema with new unit test

## Testing
- `python -m pytest -q tests/core tests/systems`
- `python -m pytest -q tests/data/test_roles_yaml.py`
