### PR TITLE
TASK 5-S-1: add renderer centering stub

### DIFF
--- a/agent_world/gui/renderer.py
+++ b/agent_world/gui/renderer.py
@@ -74,6 +74,12 @@ class Renderer:
         self.camera_world_y -= dy_screen / self.zoom
 
 
+    def center_on_entity(self, entity_id: int) -> None:
+        """Center the camera on the given entity (stub)."""
+        # Stub implementation – real centering logic added later
+        pass
+
+
     def world_to_screen(self, world_x: float, world_y: float) -> tuple[int, int]:
         if not self.window: return 0, 0
         screen_center_px_x = self.window.size[0] / 2

--- a/tests/gui/test_renderer_stub.py
+++ b/tests/gui/test_renderer_stub.py
@@ -1,0 +1,6 @@
+from agent_world.gui.renderer import Renderer
+
+
+def test_center_on_entity_stub():
+    renderer = Renderer.__new__(Renderer)
+    assert renderer.center_on_entity(1) is None


### PR DESCRIPTION
## Summary
- stub out `center_on_entity()` in `Renderer`
- add basic test ensuring the stub can be called

## Testing
- `PYTHONPATH=$(pwd) pytest -q tests/core tests/systems tests/gui/test_renderer_stub.py`