### PR TITLE
TASK 5.5-A-3: add follow command parsing

### DIFF
--- a/agent_world/utils/cli/command_parser.py
+++ b/agent_world/utils/cli/command_parser.py
@@ -97,7 +97,13 @@ def parse_command(text: str) -> Optional[CLICommand]:
     parts = text[1:].split()
     if not parts:
         return None
-    return CLICommand(name=parts[0].lower(), args=parts[1:])
+
+    cmd = parts[0].lower()
+
+    if cmd == "follow":
+        return CLICommand(name="follow", args=parts[1:2])
+
+    return CLICommand(name=cmd, args=parts[1:])
 
 
 def poll_command() -> Optional[CLICommand]:

--- a/tests/cli/test_follow_command_parser.py
+++ b/tests/cli/test_follow_command_parser.py
@@ -1,0 +1,8 @@
+from agent_world.utils.cli.command_parser import parse_command, CLICommand
+
+
+def test_follow_command_parses_correctly():
+    cmd = parse_command("/follow 7")
+    assert isinstance(cmd, CLICommand)
+    assert cmd.name == "follow"
+    assert cmd.args == ["7"]


### PR DESCRIPTION
## Summary
- extend `parse_command` with explicit `/follow` support
- test that `/follow 7` parses to the expected command

## Testing
- `python -m pytest -q tests/core tests/systems`
- `python -m pytest -q tests/cli/test_follow_command_parser.py`
