### PR TITLE
TASK 6-S-1: add AbilityUseEvent dataclass

### DIFF
--- a/agent_world/core/events.py
+++ b/agent_world/core/events.py
@@ -1,0 +1,18 @@
+"""Event dataclasses used by core systems."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class AbilityUseEvent:
+    """Record that an ability was used by an entity."""
+
+    caster_id: int
+    ability_name: str
+    target_id: int | None
+    tick: int
+
+
+__all__ = ["AbilityUseEvent"]

--- a/tests/core/test_events_stub.py
+++ b/tests/core/test_events_stub.py
@@ -1,0 +1,9 @@
+from agent_world.core.events import AbilityUseEvent
+
+
+def test_ability_use_event_fields():
+    event = AbilityUseEvent(caster_id=1, ability_name="Fireball", target_id=2, tick=42)
+    assert event.caster_id == 1
+    assert event.ability_name == "Fireball"
+    assert event.target_id == 2
+    assert event.tick == 42


### PR DESCRIPTION
## Summary
- introduce `AbilityUseEvent` to track ability usage
- test default dataclass fields

## Testing
- `PYTHONPATH=. pytest -q tests/core tests/systems`