### PR TITLE
Task 6-A-3 Recent events in prompt

### DIFF
--- a/agent_world/ai/prompt_builder.py
+++ b/agent_world/ai/prompt_builder.py
@@ -1,1 +1,39 @@
-from .llm.prompt_builder import *  # re-export for backward compatibility
+"""Prompt building utilities with recent event injection."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .llm.prompt_builder import (
+    build_prompt as _base_build_prompt,
+    _normalize,
+    _get_memories,
+)
+from ..core.world import World
+from ..core.components.event_log import EventLog
+
+
+def build_prompt(agent_id: int, world: World, *, memory_k: int = 5) -> str:
+    """Return an LLM prompt augmented with recent events for the agent."""
+
+    prompt = _base_build_prompt(agent_id, world, memory_k=memory_k)
+
+    cm = getattr(world, "component_manager", None)
+    event_log: Optional[EventLog] = None
+    if cm is not None:
+        event_log = cm.get_component(agent_id, EventLog)
+
+    if event_log and event_log.recent:
+        event_lines = [f"- {ev.ability_name} by {ev.caster_id}" for ev in event_log.recent]
+        events_section = "Recent Events:\n" + "\n".join(event_lines)
+
+        token = "--- FOCUS FOR THIS TURN ---"
+        if token in prompt:
+            prompt = prompt.replace(token, f"{events_section}\n\n{token}", 1)
+        else:
+            prompt = f"{prompt}\n\n{events_section}"
+
+    return prompt
+
+
+__all__ = ["build_prompt", "_normalize", "_get_memories"]

--- a/tests/ai/test_prompt_recent_events.py
+++ b/tests/ai/test_prompt_recent_events.py
@@ -1,0 +1,44 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.ai_state import AIState
+from agent_world.core.components.event_log import EventLog
+from agent_world.core.events import AbilityUseEvent
+from agent_world.ai.prompt_builder import build_prompt
+
+
+def _setup_world():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    return world
+
+
+def test_prompt_lists_recent_events():
+    world = _setup_world()
+    agent_id = world.entity_manager.create_entity()
+    world.component_manager.add_component(agent_id, AIState(personality="t"))
+    events = [
+        AbilityUseEvent(caster_id=2, ability_name="Fireball", target_id=None, tick=1),
+        AbilityUseEvent(caster_id=3, ability_name="Heal", target_id=agent_id, tick=2),
+    ]
+    world.component_manager.add_component(agent_id, EventLog(recent=events))
+
+    prompt = build_prompt(agent_id, world)
+
+    assert "Recent Events:" in prompt
+    assert "- Fireball by 2" in prompt
+    assert "- Heal by 3" in prompt
+
+
+def test_prompt_omits_section_when_no_events():
+    world = _setup_world()
+    agent_id = world.entity_manager.create_entity()
+    world.component_manager.add_component(agent_id, AIState(personality="t"))
+    world.component_manager.add_component(agent_id, EventLog())
+
+    prompt = build_prompt(agent_id, world)
+
+    assert "Recent Events:" not in prompt


### PR DESCRIPTION
## Summary
- extend `build_prompt` wrapper to include recent events
- test prompt shows new "Recent Events" section

## Testing
- `pytest -q tests/core tests/systems tests/ai`