### PR TITLE
TASK 6-A-2: add perception event distribution

### DIFF
--- a/agent_world/systems/ai/perception_system.py
+++ b/agent_world/systems/ai/perception_system.py
@@ -1,0 +1,51 @@
+"""Distribute ability use events to agents that can perceive them."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from ...core.components.perception_cache import PerceptionCache
+from ...core.components.event_log import EventLog
+from ...core.events import AbilityUseEvent
+import agent_world.systems.ability.ability_system as ability_mod
+
+
+class PerceptionSystem:
+    """Deliver :class:`AbilityUseEvent`s to nearby agents."""
+
+    def __init__(self, world: Any, event_queue: List[AbilityUseEvent] | None = None) -> None:
+        self.world = world
+        self.event_queue: List[AbilityUseEvent] = event_queue if event_queue is not None else getattr(
+            ability_mod, "GLOBAL_ABILITY_EVENTS", []
+        )
+        self._last_index = 0
+
+    def update(self, tick: int) -> None:
+        if not self.event_queue:
+            return
+        if self.world.entity_manager is None or self.world.component_manager is None:
+            return
+
+        em = self.world.entity_manager
+        cm = self.world.component_manager
+        new_events = self.event_queue[self._last_index :]
+        self._last_index = len(self.event_queue)
+
+        for event in new_events:
+            relevant = {event.caster_id}
+            if event.target_id is not None:
+                relevant.add(event.target_id)
+            for entity_id in list(em.all_entities.keys()):
+                cache = cm.get_component(entity_id, PerceptionCache)
+                if cache is None:
+                    continue
+                if not any(eid in cache.visible for eid in relevant):
+                    continue
+                log = cm.get_component(entity_id, EventLog)
+                if log is None:
+                    log = EventLog()
+                    cm.add_component(entity_id, log)
+                log.recent.append(event)
+
+
+__all__ = ["PerceptionSystem"]

--- a/tests/systems/test_perception_events.py
+++ b/tests/systems/test_perception_events.py
@@ -1,0 +1,43 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.components.perception_cache import PerceptionCache
+from agent_world.core.components.event_log import EventLog
+from agent_world.core.events import AbilityUseEvent
+from agent_world.systems.ai.perception_system import PerceptionSystem
+import agent_world.systems.ability.ability_system as ability_mod
+
+
+def _setup_world() -> World:
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    return world
+
+
+def test_events_visible_agents_receive(monkeypatch):
+    world = _setup_world()
+
+    caster = world.entity_manager.create_entity()
+    observer = world.entity_manager.create_entity()
+    other = world.entity_manager.create_entity()
+
+    world.component_manager.add_component(observer, PerceptionCache(visible=[caster], last_tick=0))
+    world.component_manager.add_component(observer, EventLog())
+    world.component_manager.add_component(caster, PerceptionCache(visible=[], last_tick=0))
+    world.component_manager.add_component(other, PerceptionCache(visible=[], last_tick=0))
+    world.component_manager.add_component(other, EventLog())
+
+    events: list[AbilityUseEvent] = []
+    monkeypatch.setattr(ability_mod, "GLOBAL_ABILITY_EVENTS", events, False)
+
+    system = PerceptionSystem(world)
+
+    events.append(AbilityUseEvent(caster_id=caster, ability_name="Fireball", target_id=None, tick=1))
+    system.update(1)
+
+    log_obs = world.component_manager.get_component(observer, EventLog)
+    assert log_obs.recent and log_obs.recent[0].ability_name == "Fireball"
+
+    log_other = world.component_manager.get_component(other, EventLog)
+    assert not log_other.recent


### PR DESCRIPTION
## Summary
- implement AI perception system that routes ability events to EventLog
- test that visible agents receive events via PerceptionSystem

## Testing
- `pytest -q tests/core tests/systems`