### PR TITLE
TASK 7-A-2: prepend failure note to prompts

### DIFF
--- a/agent_world/ai/prompt_builder.py
+++ b/agent_world/ai/prompt_builder.py
@@ -11,6 +11,7 @@ from .llm.prompt_builder import (
 )
 from ..core.world import World
 from ..core.components.event_log import EventLog
+from ..core.components.ai_state import AIState
 
 
 def build_prompt(agent_id: int, world: World, *, memory_k: int = 5) -> str:
@@ -20,8 +21,10 @@ def build_prompt(agent_id: int, world: World, *, memory_k: int = 5) -> str:
 
     cm = getattr(world, "component_manager", None)
     event_log: Optional[EventLog] = None
+    ai_state: Optional[AIState] = None
     if cm is not None:
         event_log = cm.get_component(agent_id, EventLog)
+        ai_state = cm.get_component(agent_id, AIState)
 
     if event_log and event_log.recent:
         event_lines = [f"- {ev.ability_name} by {ev.caster_id}" for ev in event_log.recent]
@@ -32,6 +35,9 @@ def build_prompt(agent_id: int, world: World, *, memory_k: int = 5) -> str:
             prompt = prompt.replace(token, f"{events_section}\n\n{token}", 1)
         else:
             prompt = f"{prompt}\n\n{events_section}"
+
+    if ai_state and ai_state.last_error:
+        prompt = f"SYSTEM NOTE: {ai_state.last_error}\n\n{prompt}"
 
     return prompt
 

--- a/tests/ai/test_prompt_failure_feedback.py
+++ b/tests/ai/test_prompt_failure_feedback.py
@@ -1,0 +1,36 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.ai_state import AIState
+from agent_world.ai.prompt_builder import build_prompt
+
+
+def _setup_world():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    return world
+
+
+def test_prompt_includes_error_note():
+    world = _setup_world()
+    agent_id = world.entity_manager.create_entity()
+    ai_state = AIState(personality="t")
+    ai_state.last_error = "boom"
+    world.component_manager.add_component(agent_id, ai_state)
+
+    prompt = build_prompt(agent_id, world)
+
+    assert prompt.startswith("SYSTEM NOTE: boom")
+
+
+def test_prompt_no_note_when_no_error():
+    world = _setup_world()
+    agent_id = world.entity_manager.create_entity()
+    world.component_manager.add_component(agent_id, AIState(personality="t"))
+
+    prompt = build_prompt(agent_id, world)
+
+    assert not prompt.startswith("SYSTEM NOTE:")


### PR DESCRIPTION
## Summary
- include AIState.last_error at start of prompts
- add unit test for SYSTEM NOTE behavior

## Testing
- `pytest -q tests/core tests/systems`
- `pytest -q tests/ai/test_prompt_failure_feedback.py`