### PR TITLE
Fix unbounded EventLog

### DIFF
--- a/agent_world/core/components/event_log.py
+++ b/agent_world/core/components/event_log.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass, field
-from typing import List
+from typing import Deque
 
 from agent_world.core.events import AbilityUseEvent
+
+# Maximum number of events retained in :class:`EventLog.recent`.
+MAX_RECENT_EVENTS = 20
 
 
 @dataclass(slots=True)
 class EventLog:
     """Component holding recently observed :class:`AbilityUseEvent`s."""
 
-    recent: List[AbilityUseEvent] = field(default_factory=list)
+    recent: Deque[AbilityUseEvent] = field(
+        default_factory=lambda: deque(maxlen=MAX_RECENT_EVENTS)
+    )
+
+    def __post_init__(self) -> None:
+        """Ensure ``recent`` is a deque with the correct ``maxlen``."""
+        if not isinstance(self.recent, deque) or self.recent.maxlen != MAX_RECENT_EVENTS:
+            self.recent = deque(self.recent, maxlen=MAX_RECENT_EVENTS)
 
 
-__all__ = ["EventLog"]
+__all__ = ["EventLog", "MAX_RECENT_EVENTS"]

--- a/tests/core/test_event_log_bounds.py
+++ b/tests/core/test_event_log_bounds.py
@@ -1,0 +1,14 @@
+from agent_world.core.components.event_log import EventLog, MAX_RECENT_EVENTS
+from agent_world.core.events import AbilityUseEvent
+
+
+def test_event_log_trims_to_limit():
+    log = EventLog()
+    for i in range(MAX_RECENT_EVENTS + 5):
+        log.recent.append(
+            AbilityUseEvent(caster_id=i, ability_name=str(i), target_id=None, tick=i)
+        )
+    assert len(log.recent) == MAX_RECENT_EVENTS
+    # Oldest events should be discarded
+    first = next(iter(log.recent))
+    assert first.caster_id == 5


### PR DESCRIPTION
## Summary
- enforce a maximum number of recent events retained in EventLog
- test that the log trims when over capacity

## Testing
- `export PYTHONPATH=$PWD`
- `pytest -q tests/core tests/systems`