### PR TITLE
TASK 8-S-1: add visible ability cache

### DIFF
--- a/agent_world/core/components/perception_cache.py
+++ b/agent_world/core/components/perception_cache.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List
 
+from agent_world.core.events import AbilityUseEvent
+
 
 @dataclass(slots=True)
 class PerceptionCache:
     """Stores visible entity IDs and the last tick they were updated."""
 
     visible: List[int] = field(default_factory=list)
+    visible_ability_uses: list[AbilityUseEvent] = field(default_factory=list)
     last_tick: int = 0
 

--- a/tests/core/test_perception_cache_stubs.py
+++ b/tests/core/test_perception_cache_stubs.py
@@ -1,0 +1,6 @@
+from agent_world.core.components.perception_cache import PerceptionCache
+
+
+def test_perception_cache_default_state():
+    cache = PerceptionCache()
+    assert cache.visible_ability_uses == []


### PR DESCRIPTION
## Summary
- extend `PerceptionCache` with list of visible ability uses
- import `AbilityUseEvent` for typing
- test default state of new field

## Testing
- `python -m pytest -q tests/core tests/systems`