### PR TITLE
TASK 8-S-3: store combat system instance

### DIFF
--- a/agent_world/core/world.py
+++ b/agent_world/core/world.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Tuple, TYPE_CHECKING
+from typing import Any, List, Tuple, TYPE_CHECKING, Optional
 import asyncio
 import threading
 
@@ -12,6 +12,7 @@ from ..utils.asset_generation import noise
 if TYPE_CHECKING:
     from ..systems.ai.actions import ActionQueue  # Forward reference for type hint
     from ..ai.llm.llm_manager import LLMManager
+    from ..systems.combat.combat_system import CombatSystem
 
 
 class World:
@@ -43,6 +44,8 @@ class World:
         # For GUI state
         self.gui_enabled: bool = False
         self.paused_for_angel: bool = False
+        # Reference to the main CombatSystem instance
+        self.combat_system_instance: Optional[CombatSystem] = None
 
         # Pre-computed glyph/colour data for resource types
         self._resource_defs = {

--- a/agent_world/main.py
+++ b/agent_world/main.py
@@ -142,6 +142,7 @@ def bootstrap(config_path: str | Path = Path("config.yaml")) -> World:
     sm.register(perception_sys)
     sm.register(event_perception_sys)
     sm.register(combat_sys)
+    world.combat_system_instance = combat_sys
     sm.register(pickup_sys)
     sm.register(trading_sys)
     sm.register(stealing_sys)

--- a/tests/core/test_world_system_instances.py
+++ b/tests/core/test_world_system_instances.py
@@ -1,0 +1,6 @@
+from agent_world.main import bootstrap
+
+
+def test_combat_system_instance_attached():
+    world = bootstrap(config_path="config.yaml")
+    assert getattr(world, "combat_system_instance", None) is not None


### PR DESCRIPTION
## Summary
- store optional combat system reference on World
- register CombatSystem during bootstrap and attach instance to world
- verify combat system instance is set after bootstrap

## Testing
- `PYTHONPATH=$PWD pytest -q tests/core tests/systems`