### PR TITLE
TASK 8-A-2: store visible ability uses

### DIFF
--- a/agent_world/systems/ai/perception_system.py
+++ b/agent_world/systems/ai/perception_system.py
@@ -46,6 +46,8 @@ class EventPerceptionSystem:
                     log = EventLog()
                     cm.add_component(entity_id, log)
                 log.recent.append(event)
+                # Track visible ability uses on the PerceptionCache itself
+                cache.visible_ability_uses.append(event)
 
 
 __all__ = ["EventPerceptionSystem"]

--- a/tests/systems/test_perception_events.py
+++ b/tests/systems/test_perception_events.py
@@ -33,11 +33,18 @@ def test_events_visible_agents_receive(monkeypatch):
 
     system = EventPerceptionSystem(world)
 
-    events.append(AbilityUseEvent(caster_id=caster, ability_name="Fireball", target_id=None, tick=1))
+    event = AbilityUseEvent(caster_id=caster, ability_name="Fireball", target_id=None, tick=1)
+    events.append(event)
     system.update(1)
 
     log_obs = world.component_manager.get_component(observer, EventLog)
     assert log_obs.recent and log_obs.recent[0].ability_name == "Fireball"
 
+    cache_obs = world.component_manager.get_component(observer, PerceptionCache)
+    assert cache_obs.visible_ability_uses and cache_obs.visible_ability_uses[0] == event
+
     log_other = world.component_manager.get_component(other, EventLog)
     assert not log_other.recent
+
+    cache_other = world.component_manager.get_component(other, PerceptionCache)
+    assert cache_other.visible_ability_uses == []


### PR DESCRIPTION
## Summary
- extend EventPerceptionSystem to record visible ability uses on agents' perception cache
- verify perception cache updates in event perception tests

## Testing
- `pytest -q tests/core tests/systems`
- `python -m agent_world.main --help` *(interrupted)*