### PR TITLE
TASK 8-A-1: reuse combat system instance in abilities

### DIFF
--- a/agent_world/abilities/builtin/melee_strike.py
+++ b/agent_world/abilities/builtin/melee_strike.py
@@ -38,7 +38,18 @@ class MeleeStrike(Ability):
     def execute(self, caster_id: int, world: Any, target_id: Optional[int] = None) -> None:
         if not self.can_use(caster_id, world, target_id):
             return
-        CombatSystem(world).attack(caster_id, target_id)  # type: ignore[arg-type]
+
+        combat_system = getattr(world, "combat_system_instance", None)
+        systems_manager = getattr(world, "systems_manager", None)
+        if combat_system is None and systems_manager is not None:
+            for sys_instance in systems_manager._systems:
+                if isinstance(sys_instance, CombatSystem):
+                    combat_system = sys_instance
+                    break
+        if combat_system is None:
+            combat_system = CombatSystem(world)
+
+        combat_system.attack(caster_id, target_id)  # type: ignore[arg-type]
 
 
 __all__ = ["MeleeStrike"]

--- a/agent_world/abilities/builtin/ranged.py
+++ b/agent_world/abilities/builtin/ranged.py
@@ -96,14 +96,15 @@ class ArrowShot(Ability):
 
         inv.items.pop(0) # Consume one ammo
 
-        combat_system = None
-        if hasattr(world, 'systems_manager'): 
-            for sys_instance in world.systems_manager._systems:
+        combat_system = getattr(world, "combat_system_instance", None)
+        systems_manager = getattr(world, 'systems_manager', None)
+        if combat_system is None and systems_manager is not None:
+            for sys_instance in systems_manager._systems:
                 if isinstance(sys_instance, CombatSystem):
                     combat_system = sys_instance
                     break
-        if combat_system is None: 
-             print("[Ability ArrowShot] Warning: CombatSystem not found via SystemsManager, creating new instance.")
+        if combat_system is None:
+             print("[Ability ArrowShot] Warning: CombatSystem not found; creating new instance.")
              combat_system = CombatSystem(world) # Pass world here
 
         print(f"[Ability ArrowShot] Agent {caster_id} shooting at target {actual_target_to_attack}.")

--- a/tests/abilities/test_combat_system_singleton_use.py
+++ b/tests/abilities/test_combat_system_singleton_use.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.systems_manager import SystemsManager
+from agent_world.systems.ability.ability_system import AbilitySystem
+from agent_world.systems.combat.combat_system import CombatSystem
+from agent_world.core.components.position import Position
+from agent_world.core.components.health import Health
+from agent_world.core.components.inventory import Inventory
+
+
+def _setup_world(with_singleton: bool = True) -> World:
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.systems_manager = SystemsManager()
+    combat = CombatSystem(world)
+    world.systems_manager.register(combat)
+    if with_singleton:
+        world.combat_system_instance = combat
+    return world
+
+
+def _add_basic_entities(world: World, with_inventory: bool = False) -> tuple[int, int]:
+    em = world.entity_manager
+    cm = world.component_manager
+    caster = em.create_entity()
+    target = em.create_entity()
+    cm.add_component(caster, Position(1, 1))
+    cm.add_component(target, Position(2, 1))
+    cm.add_component(target, Health(cur=10, max=10))
+    if with_inventory:
+        cm.add_component(caster, Inventory(capacity=1, items=["arrow"]))
+    return caster, target
+
+
+def test_melee_strike_uses_existing_combat_system():
+    world = _setup_world(True)
+    ability_sys = AbilitySystem(world)
+    caster, target = _add_basic_entities(world)
+
+    combat_before = world.combat_system_instance
+    assert combat_before is not None
+
+    ability_sys.use("MeleeStrike", caster, target)
+
+    assert world.combat_system_instance is combat_before
+    assert any(evt["attacker"] == caster for evt in combat_before.event_log)
+
+
+def test_arrow_shot_uses_existing_combat_system_via_manager():
+    world = _setup_world(False)
+    ability_sys = AbilitySystem(world)
+    caster, target = _add_basic_entities(world, with_inventory=True)
+
+    combat_from_manager = next(
+        s for s in world.systems_manager._systems if isinstance(s, CombatSystem)
+    )
+
+    ability_sys.use("ArrowShot", caster, target)
+
+    # ArrowShot should not instantiate a new CombatSystem
+    assert world.combat_system_instance in (None, combat_from_manager)
+    assert combat_from_manager.event_log
+    attack_event = next(
+        evt for evt in combat_from_manager.event_log if evt.get("type") == "attack"
+    )
+    assert attack_event["attacker"] == caster and attack_event["target"] == target


### PR DESCRIPTION
## Summary
- avoid creating new `CombatSystem` inside `MeleeStrike` and `ArrowShot`
- search for an existing combat system through `world.combat_system_instance` or `systems_manager`
- add tests verifying the singleton combat system is used

## Testing
- `pytest -q tests/core tests/systems`
- `pytest -q tests/abilities/test_combat_system_singleton_use.py`
