### PR TITLE
TASK 8-A-4: integrate config for models and paths

### DIFF
--- a/agent_world/ai/llm/llm_manager.py
+++ b/agent_world/ai/llm/llm_manager.py
@@ -30,9 +30,34 @@ class LLMManager:
         *,
         api_key: str | None = None,
         model: str | None = None,
+        agent_decision_model: str | None = None,
+        angel_generation_model: str | None = None,
     ) -> None:
         self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
         self.model = model or os.getenv("OPENROUTER_MODEL")
+
+        cfg: dict[str, Any] = {}
+        project_root_config_path = Path("config.yaml")
+        if project_root_config_path.exists():
+            try:
+                cfg = yaml.safe_load(project_root_config_path.read_text()) or {}
+            except Exception:  # pylint: disable=broad-except
+                cfg = {}
+        else:
+            alt = Path(__file__).resolve().parents[3] / "config.yaml"
+            if alt.exists():
+                try:
+                    cfg = yaml.safe_load(alt.read_text()) or {}
+                except Exception:
+                    cfg = {}
+        llm_cfg = cfg.get("llm", {})
+
+        self.agent_decision_model = (
+            agent_decision_model or llm_cfg.get("agent_decision_model", self.model)
+        )
+        self.angel_generation_model = (
+            angel_generation_model or llm_cfg.get("angel_generation_model", self.model)
+        )
 
         self.mode = self.current_mode()
         self.is_ready = False # Flag to indicate worker loop is ready

--- a/agent_world/core/world.py
+++ b/agent_world/core/world.py
@@ -44,8 +44,15 @@ class World:
         # For GUI state
         self.gui_enabled: bool = False
         self.paused_for_angel: bool = False
+        # Max seconds the main loop should remain paused waiting for the Angel
+        # system before auto-unpausing. Configurable via ``config.yaml``.
+        self.paused_for_angel_timeout_seconds: int = 60
         # Reference to the main CombatSystem instance
         self.combat_system_instance: Optional[CombatSystem] = None
+
+        # Optional custom file system paths (e.g. ability directories). These
+        # may be populated during bootstrap if provided in the configuration.
+        self.paths: dict[str, str] | None = None
 
         # Pre-computed glyph/colour data for resource types
         self._resource_defs = {

--- a/agent_world/systems/ability/ability_system.py
+++ b/agent_world/systems/ability/ability_system.py
@@ -32,6 +32,12 @@ class AbilitySystem:
         builtin_dir = base_dir / "builtin"
         generated_dir = base_dir / "generated"
         vault_dir = base_dir / "vault"
+
+        paths_cfg = getattr(world, "paths", None)
+        if isinstance(paths_cfg, dict):
+            builtin_dir = Path(paths_cfg.get("abilities_builtin", builtin_dir))
+            generated_dir = Path(paths_cfg.get("abilities_generated", generated_dir))
+            vault_dir = Path(paths_cfg.get("abilities_vault", vault_dir))
         
         # Ensure generated directory exists
         generated_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/core/test_config_integration.py
+++ b/tests/core/test_config_integration.py
@@ -1,0 +1,38 @@
+import yaml
+from pathlib import Path
+from agent_world.main import bootstrap
+
+
+def test_config_models_and_paths(tmp_path):
+    cfg = {
+        "world": {"size": [5, 5]},
+        "llm": {
+            "mode": "offline",
+            "agent_decision_model": "agent-test-model",
+            "angel_generation_model": "angel-test-model",
+        },
+        "paths": {
+            "abilities_builtin": str(tmp_path / "builtin"),
+            "abilities_generated": str(tmp_path / "generated"),
+            "abilities_vault": str(tmp_path / "vault"),
+        },
+    }
+    for p in cfg["paths"].values():
+        Path(p).mkdir(parents=True, exist_ok=True)
+    config_file = tmp_path / "cfg.yaml"
+    config_file.write_text(yaml.dump(cfg))
+
+    world = bootstrap(config_path=config_file)
+
+    llm = world.llm_manager_instance
+    assert llm.agent_decision_model == "agent-test-model"
+    assert llm.angel_generation_model == "angel-test-model"
+
+    ability_sys = world.ability_system_instance
+    assert ability_sys is not None
+    expected = [
+        Path(cfg["paths"]["abilities_builtin"]),
+        Path(cfg["paths"]["abilities_generated"]),
+        Path(cfg["paths"]["abilities_vault"]),
+    ]
+    assert ability_sys.search_dirs == expected


### PR DESCRIPTION
## Summary
- allow world to store paths and pause timeout
- add ability system path configuration
- load decision/generation models in LLMManager
- expose angel pause timeout control in main loop
- integration test for config models and paths

## Testing
- `PYTHONPATH=. pytest -q tests/core tests/systems`