### PR TITLE
Task 8-A-5

### DIFF
--- a/agent_world/ai/angel/generator.py
+++ b/agent_world/ai/angel/generator.py
@@ -50,54 +50,7 @@ def generate_ability(desc: str, *, stub_code: str | None = None) -> Path:
     imports_for_stub_section = ""
     can_use_logic_body = "return True # Default can_use"
 
-    specific_heal_desc_trigger = "a simple self heal ability for 5 health"
-    if desc.strip().lower() == specific_heal_desc_trigger.lower():
-        imports_for_stub_section = "from agent_world.core.components.health import Health"
-        final_stub_code_body = """
-        if world and hasattr(world, 'component_manager') and hasattr(world, 'entity_manager'):
-            cm = world.component_manager; em = world.entity_manager
-            if not em.has_entity(caster_id): print(f"Caster {caster_id} not found."); return
-            health_comp = cm.get_component(caster_id, Health)
-            if health_comp:
-                heal_amount = 5; old_health = health_comp.cur
-                health_comp.cur = min(health_comp.max, health_comp.cur + heal_amount)
-                print(f"Agent {caster_id} used {self.__class__.__name__} and healed for {health_comp.cur - old_health} HP. Health: {health_comp.cur}/{health_comp.max}")
-            else: print(f"Agent {caster_id} no Health component.")
-        else: print(f"Agent {caster_id} world/managers missing.")
-"""
-    # --- Disintegrate Obstacle Ability ---
-    elif "disintegrate obstacle" in desc.strip().lower() or \
-         "remove obstacle" in desc.strip().lower() or \
-         "clear obstacle" in desc.strip().lower():
-        
-        imports_for_stub_section = (
-            "from agent_world.systems.movement.pathfinding import OBSTACLES, is_blocked\n"
-            # Position not strictly needed if we always target (50,49) but good for future.
-            "from agent_world.core.components.position import Position" 
-        )
-        # MODIFIED: can_use is now always True if the ability is called.
-        # The prompt_builder's critical prompt logic should be the main gatekeeper for when to suggest using it.
-        can_use_logic_body = """
-        # For this scenario, if the LLM decides to use it based on the critical prompt,
-        # we assume it's a valid situation. The obstacle check is done in execute.
-        return True
-"""
-        # execute: always try to remove (50,49)
-        final_stub_code_body = """
-        # Note: OBSTACLES, is_blocked, Position are imported.
-        obstacle_to_remove = (50,49) # Hardcoded for the specific scenario
-            
-        if is_blocked(obstacle_to_remove): # Check if it's currently considered an obstacle
-            if obstacle_to_remove in OBSTACLES: # Double check it's in the actual set
-                OBSTACLES.discard(obstacle_to_remove)
-                print(f"Agent {caster_id} used {self.__class__.__name__} and REMOVED obstacle at {obstacle_to_remove}! Obstacles left: {len(OBSTACLES)}")
-            else:
-                 print(f"Agent {caster_id} {self.__class__.__name__}: Obstacle at {obstacle_to_remove} was is_blocked() but not in OBSTACLES set.")
-        else:
-             print(f"Agent {caster_id} used {self.__class__.__name__}, but no obstacle was found/already cleared at {obstacle_to_remove}.")
-"""
-
-    elif final_stub_code_body is None: 
+    if final_stub_code_body is None:
         clean_desc_for_print = desc.replace('"', '\\"').replace("'", "\\'")
         final_stub_code_body = f"print(f\"Agent {{caster_id}} used {{self.__class__.__name__}} targeting {{target_id}} (desc: '{clean_desc_for_print}')\")"
     

--- a/tests/angel/test_generic_ability_stubs.py
+++ b/tests/angel/test_generic_ability_stubs.py
@@ -1,0 +1,24 @@
+import pytest
+from agent_world.ai.angel import generator as angel_generator
+
+
+@pytest.mark.parametrize(
+    "desc",
+    [
+        "a simple self heal ability for 5 health",
+        "disintegrate obstacle in front",
+    ],
+)
+def test_generate_generic_stub(monkeypatch, tmp_path, desc):
+    monkeypatch.setattr(angel_generator, "GENERATED_DIR", tmp_path)
+    path = angel_generator.generate_ability(desc)
+    text = path.read_text()
+
+    # Generic stub should not contain previous special-case logic
+    assert "from agent_world.core.components.health" not in text
+    assert "OBSTACLES" not in text
+    assert "is_blocked" not in text
+
+    # Should contain the default print stub
+    assert "print(f\"Agent {caster_id} used {self.__class__.__name__}" in text
+


### PR DESCRIPTION
## Summary
- simplify `generate_ability` by removing hardcoded heal and disintegrate cases
- use generic stub when no stub_code provided
- add tests ensuring special descriptions yield generic stubs

## Testing
- `PYTHONPATH=. pytest -q tests/angel/test_generic_ability_stubs.py tests/core tests/systems`