### PR TITLE
TASK 8-A-3: add persistent event logging

### DIFF
--- a/agent_world/ai/llm/llm_manager.py
+++ b/agent_world/ai/llm/llm_manager.py
@@ -14,6 +14,11 @@ import json # For pretty printing JSON response
 
 import httpx
 import yaml
+from ...persistence.event_log import (
+    append_event,
+    LLM_REQUEST,
+    LLM_RESPONSE,
+)
 
 from .cache import LLMCache
 
@@ -65,6 +70,7 @@ class LLMManager:
         )
         self.loop: asyncio.AbstractEventLoop | None = None
         self._processing_thread: threading.Thread | None = None
+        self.world: Any | None = None
 
 
     # ------------------------------------------------------------------
@@ -133,9 +139,22 @@ class LLMManager:
         print(f"[LLMManager DEBUG process_queue_item] Processing prompt_id {prompt_id} from queue.")
         # --- END MODIFIED LOGGING ---
 
-        result = "<wait>" 
-        if self.offline: 
-            if self.mode == "echo": 
+        world = getattr(self, "world", None)
+        if world is not None:
+            dest = getattr(world, "persistent_event_log_path", None)
+            if dest is None:
+                dest = Path("persistent_events.log")
+                world.persistent_event_log_path = dest
+            tick = getattr(getattr(world, "time_manager", None), "tick_counter", 0)
+            try:
+                append_event(dest, tick, LLM_REQUEST, {"prompt_id": prompt_id, "prompt": prompt})
+            except Exception:
+                pass
+
+        raw_response_text = None
+        result = "<wait>"
+        if self.offline:
+            if self.mode == "echo":
                 lines = [ln.strip() for ln in prompt.splitlines() if ln.strip()]
                 result = lines[-1] if lines else ""
         else: 
@@ -210,6 +229,14 @@ class LLMManager:
         # --- MODIFIED LOGGING: Full result string, newlines replaced for console readability ---
         print(f"[LLMManager DEBUG process_queue_item] Result for prompt_id {prompt_id}: '{result.replace(chr(10), '//')}'")
         # --- END MODIFIED LOGGING ---
+
+        if world is not None:
+            response_text = raw_response_text if raw_response_text is not None else result
+            try:
+                append_event(dest, tick, LLM_RESPONSE, {"prompt_id": prompt_id, "response": response_text})
+            except Exception:
+                pass
+
         self.cache.put(prompt, result)
         if not fut.done():
             fut.set_result(result)
@@ -222,6 +249,8 @@ class LLMManager:
 
     def start_processing_loop(self, world_ref: Any) -> None:
         """Run queue processing in a background thread."""
+
+        self.world = world_ref
 
         def _run() -> None:
             self.loop = asyncio.new_event_loop()

--- a/agent_world/persistence/event_log.py
+++ b/agent_world/persistence/event_log.py
@@ -9,6 +9,11 @@ from typing import Any, Dict, Iterator, List
 
 import yaml
 
+# Event type constants used by various systems
+LLM_REQUEST = "LLM_REQUEST"
+LLM_RESPONSE = "LLM_RESPONSE"
+ANGEL_ACTION = "ANGEL_ACTION"
+
 
 def _log_retention_bytes() -> int:
     """Return log rotation threshold in bytes from ``config.yaml``."""
@@ -88,4 +93,11 @@ class EventLog:
         yield from iter_events(self.path)
 
 
-__all__ = ["EventLog", "append_event", "iter_events"]
+__all__ = [
+    "EventLog",
+    "append_event",
+    "iter_events",
+    "LLM_REQUEST",
+    "LLM_RESPONSE",
+    "ANGEL_ACTION",
+]

--- a/tests/persistence/test_llm_angel_event_logging.py
+++ b/tests/persistence/test_llm_angel_event_logging.py
@@ -1,0 +1,69 @@
+import asyncio
+
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.ai.llm.llm_manager import LLMManager
+from agent_world.ai.angel.system import get_angel_system
+from agent_world.ai.angel import generator as angel_generator
+from agent_world.persistence.event_log import (
+    iter_events,
+    LLM_REQUEST,
+    LLM_RESPONSE,
+    ANGEL_ACTION,
+)
+
+
+async def _process_prompt(llm: LLMManager, prompt: str) -> str:
+    fut: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+    await llm.queue.put((prompt, fut, "pid"))
+    await llm.process_queue_item()
+    return fut.result()
+
+
+def test_llm_events_logged(tmp_path):
+    world = World((5, 5))
+    world.time_manager = TimeManager()
+    world.persistent_event_log_path = tmp_path / "log.json"
+
+    llm = LLMManager()
+    llm.mode = "echo"
+    llm.offline = True
+    llm.world = world
+
+    result = asyncio.run(_process_prompt(llm, "say\nhello"))
+    assert result == "hello"
+
+    events = list(iter_events(world.persistent_event_log_path))
+    assert events[0]["event_type"] == LLM_REQUEST
+    assert events[0]["data"]["prompt"] == "say\nhello"
+    assert events[1]["event_type"] == LLM_RESPONSE
+    assert events[1]["data"]["response"] == "hello"
+
+
+def test_angel_events_logged(monkeypatch, tmp_path):
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    world.persistent_event_log_path = tmp_path / "angel.log"
+
+    system = get_angel_system(world)
+
+    # Vault hit path
+    system.generate_and_grant(1, "simple fireball ability")
+    events = list(iter_events(world.persistent_event_log_path))
+    assert any(e["event_type"] == ANGEL_ACTION and e["data"].get("stage") == "vault_hit" for e in events)
+    assert any(e["event_type"] == ANGEL_ACTION and e["data"].get("stage") == "granted" for e in events)
+
+    # LLM generation failure path
+    def fail_generate(desc: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(angel_generator, "generate_ability", fail_generate)
+    system.generate_and_grant(2, "broken ability")
+
+    events = list(iter_events(world.persistent_event_log_path))
+    assert any(e["event_type"] == ANGEL_ACTION and e["data"].get("stage") == "failure" for e in events)
+


### PR DESCRIPTION
## Summary
- define LLM_REQUEST, LLM_RESPONSE and ANGEL_ACTION constants
- log prompts/responses from `LLMManager.process_queue_item`
- record angel system decisions via `ANGEL_ACTION` events
- test persistent logging for LLM and AngelSystem

## Testing
- `pytest -q tests/persistence/test_llm_angel_event_logging.py`
- `pytest -q tests/core tests/systems`