### PR TITLE
TASK 8-B-1: use perception cache for prompt events

### DIFF
--- a/agent_world/ai/prompt_builder.py
+++ b/agent_world/ai/prompt_builder.py
@@ -11,6 +11,7 @@ from .llm.prompt_builder import (
 )
 from ..core.world import World
 from ..core.components.event_log import EventLog
+from ..core.components.perception_cache import PerceptionCache
 from ..core.components.ai_state import AIState
 
 
@@ -22,12 +23,20 @@ def build_prompt(agent_id: int, world: World, *, memory_k: int = 5) -> str:
     cm = getattr(world, "component_manager", None)
     event_log: Optional[EventLog] = None
     ai_state: Optional[AIState] = None
+    perception_cache: Optional[PerceptionCache] = None
     if cm is not None:
+        perception_cache = cm.get_component(agent_id, PerceptionCache)
         event_log = cm.get_component(agent_id, EventLog)
         ai_state = cm.get_component(agent_id, AIState)
 
-    if event_log and event_log.recent:
-        event_lines = [f"- {ev.ability_name} by {ev.caster_id}" for ev in event_log.recent]
+    events = []
+    if perception_cache and perception_cache.visible_ability_uses:
+        events = perception_cache.visible_ability_uses
+    elif event_log and event_log.recent:
+        events = list(event_log.recent)
+
+    if events:
+        event_lines = [f"- {ev.ability_name} by {ev.caster_id}" for ev in events]
         events_section = "Recent Events:\n" + "\n".join(event_lines)
 
         token = "--- FOCUS FOR THIS TURN ---"

--- a/tests/ai/test_prompt_visible_ability_uses.py
+++ b/tests/ai/test_prompt_visible_ability_uses.py
@@ -1,0 +1,35 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.ai_state import AIState
+from agent_world.core.components.event_log import EventLog
+from agent_world.core.components.perception_cache import PerceptionCache
+from agent_world.core.events import AbilityUseEvent
+from agent_world.ai.prompt_builder import build_prompt
+
+
+def _setup_world():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    return world
+
+
+def test_prompt_uses_visible_ability_uses():
+    world = _setup_world()
+    agent_id = world.entity_manager.create_entity()
+    world.component_manager.add_component(agent_id, AIState(personality="t"))
+
+    event = AbilityUseEvent(caster_id=2, ability_name="Fireball", target_id=None, tick=1)
+    cache = PerceptionCache(visible=[], visible_ability_uses=[event], last_tick=0)
+    world.component_manager.add_component(agent_id, cache)
+    # Ensure EventLog is present but empty to confirm source
+    world.component_manager.add_component(agent_id, EventLog())
+
+    prompt = build_prompt(agent_id, world)
+
+    assert "Recent Events:" in prompt
+    assert "- Fireball by 2" in prompt
+


### PR DESCRIPTION
## Summary
- use `PerceptionCache.visible_ability_uses` when building prompts
- add test ensuring prompt includes visible ability uses

## Testing
- `pytest -q tests/core tests/systems tests/ai/test_prompt_visible_ability_uses.py`