### PR TITLE
TASK 9-S-3: add scenario base class and CLI stub

### DIFF
--- a/agent_world/scenarios/__init__.py
+++ b/agent_world/scenarios/__init__.py
@@ -1,0 +1,1 @@
+"""Scenario package."""

--- a/agent_world/scenarios/base_scenario.py
+++ b/agent_world/scenarios/base_scenario.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseScenario(ABC):
+    """Abstract base class for gameplay scenarios."""
+
+    @abstractmethod
+    def setup(self, world: Any) -> None:
+        """Populate the world with scenario entities and state."""
+        pass
+
+    @abstractmethod
+    def get_name(self) -> str:
+        """Return a human readable name for the scenario."""
+        pass

--- a/agent_world/utils/cli/commands.py
+++ b/agent_world/utils/cli/commands.py
@@ -317,6 +317,11 @@ def follow(world: Any, entity_id_str: str | None, state: Dict[str, Any]) -> None
     print(f"Following entity {entity_id}")
 
 
+def scenario(world: Any, name: str) -> None:
+    """Placeholder for loading and running a scenario."""
+    print(f"Scenario command received for '{name}' (stub).")
+
+
 def help_command(state: Dict[str, Any]) -> None:
     print("\nAvailable commands:")
     print("  /help                - Show this help message.")
@@ -376,6 +381,9 @@ def execute(command: str, args: list[str], world: Any, state: Dict[str, Any]) ->
     elif cmd_lower == "follow" and args:
         follow(world, args[0], state)
         # return_value remains None
+    elif cmd_lower == "scenario" and args:
+        scenario(world, args[0])
+        # return_value remains None
     elif cmd_lower == "quit":
         state["running"] = False
         print("Quit command received. Shutting down...")
@@ -388,5 +396,5 @@ def execute(command: str, args: list[str], world: Any, state: Dict[str, Any]) ->
 
 __all__ = [
     "pause", "step", "save", "reload_abilities", "profile", "spawn", "debug",
-    "gui", "fps", "follow", "help_command", "execute",
+    "gui", "fps", "follow", "scenario", "help_command", "execute",
 ]

--- a/tests/scenarios/test_scenario_stubs.py
+++ b/tests/scenarios/test_scenario_stubs.py
@@ -1,0 +1,13 @@
+from agent_world.scenarios.base_scenario import BaseScenario
+from agent_world.utils.cli.command_parser import parse_command, CLICommand
+
+
+def test_base_scenario_importable():
+    assert BaseScenario.__name__ == "BaseScenario"
+
+
+def test_scenario_command_parses_correctly():
+    cmd = parse_command("/scenario default")
+    assert isinstance(cmd, CLICommand)
+    assert cmd.name == "scenario"
+    assert cmd.args == ["default"]


### PR DESCRIPTION
## Summary
- stub scenario package
- implement `BaseScenario` abstract base class
- add `/scenario` CLI command placeholder
- test scenario stub import and command parsing

## Testing
- `pytest -q tests/scenarios/test_scenario_stubs.py tests/cli/test_follow_command_parser.py tests/cli/test_spawn_roles.py tests/angel/test_angel_system_stub.py tests/angel/test_angel_system_registration_stub.py tests/core/test_known_abilities_stub.py tests/core/test_role_stub.py`