### PR TITLE
TASK 9-A-1: implement scenario loader and default pickup

### DIFF
--- a/agent_world/scenarios/default_pickup_scenario.py
+++ b/agent_world/scenarios/default_pickup_scenario.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base_scenario import BaseScenario
+from ..utils.cli import commands
+from ..core.components.ai_state import AIState
+from ..core.components.position import Position
+from ..systems.movement.pathfinding import set_obstacles, clear_obstacles
+
+
+class DefaultPickupScenario(BaseScenario):
+    """Basic scenario where an agent must pick up a nearby item."""
+
+    def get_name(self) -> str:
+        return "Default Pickup"
+
+    def setup(self, world: Any) -> None:
+        """Spawn an agent and item with a blocking obstacle."""
+
+        clear_obstacles()
+
+        center_x = world.size[0] // 2
+        center_y = world.size[1] // 2
+
+        agent_id = commands.spawn(world, "npc", str(center_x), str(center_y))
+        item_x = center_x
+        item_y = center_y - 2
+        item_id = commands.spawn(world, "item", str(item_x), str(item_y))
+
+        if agent_id and item_id and world.component_manager:
+            ai_state = world.component_manager.get_component(agent_id, AIState)
+            if ai_state:
+                ai_state.goals = [f"Acquire item {item_id}"]
+                print(
+                    f"[Scenario] Agent {agent_id} at ({center_x},{center_y}) given goal: {ai_state.goals}"
+                )
+            item_pos = world.component_manager.get_component(item_id, Position)
+            if item_pos:
+                print(
+                    f"[Scenario] Item {item_id} spawned at ({item_pos.x},{item_pos.y}) for Agent {agent_id}."
+                )
+            else:
+                print(
+                    f"[Scenario WARNING] Item {item_id} spawned but has no Position component!"
+                )
+
+        obstacle_pos = (center_x, center_y - 1)
+        set_obstacles([obstacle_pos])
+        print(f"[Scenario] Obstacle placed at {obstacle_pos}")

--- a/agent_world/utils/cli/commands.py
+++ b/agent_world/utils/cli/commands.py
@@ -318,8 +318,15 @@ def follow(world: Any, entity_id_str: str | None, state: Dict[str, Any]) -> None
 
 
 def scenario(world: Any, name: str) -> None:
-    """Placeholder for loading and running a scenario."""
-    print(f"Scenario command received for '{name}' (stub).")
+    """Load and run a scenario by name."""
+
+    name = name.lower()
+    if name == "default_pickup":
+        from ...scenarios.default_pickup_scenario import DefaultPickupScenario
+
+        DefaultPickupScenario().setup(world)
+    else:
+        print(f"Unknown scenario: {name}")
 
 
 def help_command(state: Dict[str, Any]) -> None:
@@ -334,6 +341,7 @@ def help_command(state: Dict[str, Any]) -> None:
     print("  /spawn <kind> [x] [y]- Spawn entity (npc, item). E.g., /spawn npc 5 5 or /spawn item")
     print("  /debug <entity_id>   - Print component data for an entity.")
     print("  /follow <entity_id>  - Center camera on an entity each tick.")
+    print("  /scenario <name>     - Load a scenario by name (e.g., default_pickup).")
     print("  /quit                - Exit the application.\n")
 
 

--- a/tests/scenarios/test_pickup_scenario_command.py
+++ b/tests/scenarios/test_pickup_scenario_command.py
@@ -1,0 +1,48 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.spatial.spatial_index import SpatialGrid
+from agent_world.core.components.ai_state import AIState
+from agent_world.scenarios.default_pickup_scenario import DefaultPickupScenario
+from agent_world.utils.cli import commands
+from agent_world.systems.movement.pathfinding import OBSTACLES
+
+
+def _setup_world():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.spatial_index = SpatialGrid(1)
+    return world
+
+
+def _validate_world(world: World):
+    em = world.entity_manager
+    cm = world.component_manager
+    center_x = world.size[0] // 2
+    center_y = world.size[1] // 2
+
+    assert em is not None and cm is not None
+    assert len(em.all_entities) == 2
+    ids = sorted(em.all_entities.keys())
+    ai_state = cm.get_component(ids[0], AIState)
+    if ai_state:
+        agent_id, item_id = ids[0], ids[1]
+    else:
+        agent_id, item_id = ids[1], ids[0]
+        ai_state = cm.get_component(agent_id, AIState)
+    assert ai_state is not None
+    assert ai_state.goals == [f"Acquire item {item_id}"]
+    assert (center_x, center_y - 1) in OBSTACLES
+
+
+def test_default_pickup_scenario_setup():
+    world = _setup_world()
+    DefaultPickupScenario().setup(world)
+    _validate_world(world)
+
+
+def test_scenario_command_executes():
+    world = _setup_world()
+    commands.scenario(world, "default_pickup")
+    _validate_world(world)


### PR DESCRIPTION
## Summary
- create `DefaultPickupScenario` and move spawn logic from `main.py`
- run the scenario by default and expose `/scenario` CLI command
- update help text with scenario command
- add tests for default pickup scenario

## Testing
- `pytest -q tests/scenarios/test_pickup_scenario_command.py tests/scenarios/test_scenario_stubs.py tests/cli/test_follow_command_parser.py tests/cli/test_spawn_roles.py`