### PR TITLE
TASK 9-A-3: integrate AngelSystem with systems manager

### DIFF
--- a/agent_world/ai/angel/system.py
+++ b/agent_world/ai/angel/system.py
@@ -19,6 +19,7 @@ class AngelSystem:
 
     def __init__(self, world: Any) -> None:
         self.world = world
+        self.request_queue: list[tuple[int, str]] = []
 
     # ------------------------------------------------------------------
     # Lifecycle stubs
@@ -30,6 +31,11 @@ class AngelSystem:
     def process_pending_requests(self) -> None:
         """Placeholder for processing queued Angel requests."""
         return None
+
+    def queue_request(self, agent_id: int, description: str) -> dict:
+        """Queue an ability generation request and process immediately for now."""
+        self.request_queue.append((agent_id, description))
+        return self.generate_and_grant(agent_id, description)
 
     def _grant_to_agent(self, agent_id: int, class_name: str) -> None:
         cm = getattr(self.world, "component_manager", None)

--- a/agent_world/main.py
+++ b/agent_world/main.py
@@ -37,6 +37,7 @@ from .systems.ability.ability_system import AbilitySystem
 from .systems.ai.ai_reasoning_system import AIReasoningSystem
 from .systems.ai.behavior_tree_system import BehaviorTreeSystem
 from .ai.behaviors.creature_bt import build_creature_tree
+from .ai.angel.system import get_angel_system
 
 try:
     from .systems.ai.action_execution_system import ActionExecutionSystem
@@ -153,6 +154,8 @@ def bootstrap(config_path: str | Path = Path("config.yaml")) -> World:
     sm.register(ability_sys) # AbilitySystem needs to be registered
     if not hasattr(world, "ability_system_instance"):
         world.ability_system_instance = ability_sys
+    angel_system = get_angel_system(world)
+    sm.register(angel_system)
     sm.register(ai_reasoning_sys)
 
     if ActionExecutionSystem is not None:
@@ -397,6 +400,8 @@ def main() -> None:
 
                     tm.sleep_until_next_tick()
                 else:
+                    if getattr(world, "angel_system_instance", None):
+                        world.angel_system_instance.process_pending_requests()
                     time.sleep(0.016)
 
                 step_once = False

--- a/agent_world/systems/ai/action_execution_system.py
+++ b/agent_world/systems/ai/action_execution_system.py
@@ -85,18 +85,15 @@ class ActionExecutionSystem:
             # --- HANDLE GenerateAbilityAction ---
             elif isinstance(action, GenerateAbilityAction):
                 self.world.paused_for_angel = True
+                angel_system = get_angel_system(self.world)
                 try:
-                    result = get_angel_system(self.world).generate_and_grant(
-                        action.actor, action.description
+                    angel_system.queue_request(action.actor, action.description)
+                    print(
+                        f"[Tick {tick}][ActionExec] Agent {action.actor} queued generation of ability '{action.description}'."
                     )
-                    log_msg = (
-                        f"Agent {action.actor} requested generation of ability: '{action.description}'. "
-                        f"Result: {result}"
-                    )
-                    print(f"[Tick {tick}][ActionExec] {log_msg}")
                 except Exception as e:
                     error_msg = (
-                        f"Error during ability generation for agent {action.actor} "
+                        f"Error during ability generation request for agent {action.actor} "
                         f"(desc: '{action.description}'): {e}"
                     )
                     print(f"[Tick {tick}][ActionExec ERROR] {error_msg}")

--- a/tests/angel/test_angel_system_integration.py
+++ b/tests/angel/test_angel_system_integration.py
@@ -1,0 +1,59 @@
+import time
+from agent_world.main import bootstrap
+from agent_world.core.world import World
+from agent_world.ai.angel.system import AngelSystem, get_angel_system
+from agent_world.systems.ai.actions import ActionQueue, GenerateAbilityAction
+from agent_world.systems.ai.action_execution_system import ActionExecutionSystem
+from agent_world.systems.combat.combat_system import CombatSystem
+
+
+def test_angel_system_registered_and_process_called(monkeypatch):
+    world = bootstrap(config_path="config.yaml")
+    assert isinstance(world.angel_system_instance, AngelSystem)
+    assert world.angel_system_instance in list(world.systems_manager)
+
+    called = {}
+
+    def fake_process() -> None:
+        called["processed"] = True
+
+    monkeypatch.setattr(world.angel_system_instance, "process_pending_requests", fake_process)
+    world.paused_for_angel = True
+    tm = world.time_manager
+    tm.tick_counter = 0
+
+    if not world.paused_for_angel:
+        if world.systems_manager:
+            world.systems_manager.update(world, tm.tick_counter)
+        tm.sleep_until_next_tick()
+    else:
+        world.angel_system_instance.process_pending_requests()
+
+    assert called.get("processed") is True
+
+
+def test_generate_ability_action_queues(monkeypatch):
+    world = World((5, 5))
+    world.component_manager = object()
+    queue = ActionQueue()
+    combat = CombatSystem(world)
+    system = ActionExecutionSystem(world, queue, combat)
+    angel = get_angel_system(world)
+
+    monkeypatch.setattr(angel, "generate_and_grant", lambda a, d: {"status": "stub"})
+    captured = {}
+    orig_queue = angel.queue_request
+
+    def spy_queue(actor: int, desc: str):
+        captured["actor"] = actor
+        captured["desc"] = desc
+        return orig_queue(actor, desc)
+
+    monkeypatch.setattr(angel, "queue_request", spy_queue)
+
+    queue._queue.append(GenerateAbilityAction(actor=1, description="test"))
+    system.update(0)
+
+    assert captured == {"actor": 1, "desc": "test"}
+    assert (1, "test") in angel.request_queue
+    assert world.paused_for_angel is False


### PR DESCRIPTION
## Summary
- add request queue handling to `AngelSystem`
- queue ability requests from `ActionExecutionSystem`
- register AngelSystem during bootstrap
- invoke AngelSystem when the world is paused
- test AngelSystem registration and queuing

## Testing
- `PYTHONPATH=$PWD pytest -q tests/core tests/systems tests/angel`