### PR TITLE
Task 9-A-7: unify combat and crafting logging

### DIFF
--- a/agent_world/main.py
+++ b/agent_world/main.py
@@ -126,13 +126,11 @@ def bootstrap(config_path: str | Path = Path("config.yaml")) -> World:
     view_radius = int(perception_cfg.get("view_radius", 10))
     perception_sys = VisibilityPerceptionSystem(world, view_radius=view_radius)
     event_perception_sys = EventPerceptionSystem(world)
-    combat_event_log: list[dict[str, Any]] = []
-    combat_sys = CombatSystem(world, event_log=combat_event_log) # Renamed
+    combat_sys = CombatSystem(world)  # Renamed
     pickup_sys = PickupSystem(world) # Renamed
     trading_sys = TradingSystem(world) # Renamed
     stealing_sys = StealingSystem(world) # Renamed
-    crafting_event_log: list[dict[str, Any]] = []
-    crafting_sys = CraftingSystem(world, event_log=crafting_event_log) # Renamed
+    crafting_sys = CraftingSystem(world)  # Renamed
     ability_sys = AbilitySystem(world) # Renamed
     ai_reasoning_sys = AIReasoningSystem(world, world.llm_manager_instance, world.raw_actions_with_actor) # Renamed
 

--- a/agent_world/persistence/event_log.py
+++ b/agent_world/persistence/event_log.py
@@ -13,6 +13,9 @@ import yaml
 LLM_REQUEST = "LLM_REQUEST"
 LLM_RESPONSE = "LLM_RESPONSE"
 ANGEL_ACTION = "ANGEL_ACTION"
+COMBAT_ATTACK = "COMBAT_ATTACK"
+COMBAT_DEATH = "COMBAT_DEATH"
+CRAFT = "CRAFT"
 
 
 def _log_retention_bytes() -> int:
@@ -100,4 +103,7 @@ __all__ = [
     "LLM_REQUEST",
     "LLM_RESPONSE",
     "ANGEL_ACTION",
+    "COMBAT_ATTACK",
+    "COMBAT_DEATH",
+    "CRAFT",
 ]

--- a/tests/persistence/test_unified_event_logging.py
+++ b/tests/persistence/test_unified_event_logging.py
@@ -1,0 +1,50 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.position import Position
+from agent_world.core.components.health import Health
+from agent_world.core.components.inventory import Inventory
+from agent_world.persistence.event_log import (
+    iter_events,
+    COMBAT_ATTACK,
+    COMBAT_DEATH,
+    CRAFT,
+)
+from agent_world.systems.combat.combat_system import CombatSystem
+from agent_world.systems.interaction.crafting import CraftingSystem
+
+
+def test_combat_and_crafting_logged(tmp_path):
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    world.persistent_event_log_path = tmp_path / "events.json"
+
+    combat = CombatSystem(world)
+    crafting = CraftingSystem(world)
+
+    em = world.entity_manager
+    cm = world.component_manager
+
+    attacker = em.create_entity()
+    target = em.create_entity()
+    cm.add_component(attacker, Position(1, 1))
+    cm.add_component(target, Position(1, 2))
+    cm.add_component(target, Health(cur=10, max=10))
+
+    world.time_manager.tick_counter = 1
+    combat.attack(attacker, target)
+
+    crafter = em.create_entity()
+    item = em.create_entity()
+    cm.add_component(crafter, Inventory(capacity=5, items=[item]))
+    world.time_manager.tick_counter = 2
+    crafting.craft(crafter, "basic")
+
+    events = list(iter_events(world.persistent_event_log_path))
+    types = [e["event_type"] for e in events]
+    assert COMBAT_ATTACK in types
+    assert COMBAT_DEATH in types
+    assert CRAFT in types


### PR DESCRIPTION
## Summary
- route combat and crafting events to persistent log
- add COMBAT and CRAFT event types
- drop local logs from system initialization
- verify combat and crafting events written to persistent log

## Testing
- `pytest -q tests/core tests/systems tests/persistence/test_unified_event_logging.py`