### PR TITLE
Task 9-A-2 centralized config

### DIFF
--- a/agent_world/persistence/event_log.py
+++ b/agent_world/persistence/event_log.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterator, List
 
-import yaml
+from agent_world.config import CONFIG
 
 # Event type constants used by various systems
 LLM_REQUEST = "LLM_REQUEST"
@@ -19,17 +19,14 @@ CRAFT = "CRAFT"
 
 
 def _log_retention_bytes() -> int:
-    """Return log rotation threshold in bytes from ``config.yaml``."""
-    path = Path(__file__).resolve().parents[2] / "config.yaml"
+    """Return log rotation threshold in bytes from the :mod:`agent_world.config`."""
     default_mb = 50
-    if path.exists():
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                cfg = yaml.safe_load(fh) or {}
-            default_mb = int(cfg.get("cache", {}).get("log_retention_mb", default_mb))
-        except Exception:
-            pass
-    return default_mb * 1024 * 1024
+    cache_cfg = CONFIG.cache or {}
+    try:
+        mb = int(cache_cfg.get("log_retention_mb", default_mb))
+    except Exception:  # pylint: disable=broad-except
+        mb = default_mb
+    return mb * 1024 * 1024
 
 
 def _rotate_log(path: Path) -> None:

--- a/agent_world/systems/ability/ability_system.py
+++ b/agent_world/systems/ability/ability_system.py
@@ -11,6 +11,8 @@ import inspect
 from types import ModuleType
 from typing import Any, Dict, List, Sequence, Optional
 
+from ...config import CONFIG
+
 from ...core.events import AbilityUseEvent
 
 from ...abilities.base import Ability
@@ -26,14 +28,23 @@ GLOBAL_ABILITY_EVENT_QUEUE: List[AbilityUseEvent] = []
 class AbilitySystem:
     """Load, hot-reload and execute ability modules."""
 
-    def __init__(self, world: Any, search_dirs: Sequence[Path] | None = None) -> None:
+    def __init__(
+        self,
+        world: Any,
+        search_dirs: Sequence[Path] | None = None,
+        *,
+        paths_cfg: Optional[Dict[str, str]] = None,
+    ) -> None:
         self.world = world
         base_dir = Path(__file__).resolve().parents[2] / "abilities"
         builtin_dir = base_dir / "builtin"
         generated_dir = base_dir / "generated"
         vault_dir = base_dir / "vault"
 
-        paths_cfg = getattr(world, "paths", None)
+        if paths_cfg is None:
+            paths_cfg = getattr(world, "paths", None)
+        if paths_cfg is None:
+            paths_cfg = CONFIG.paths
         if isinstance(paths_cfg, dict):
             builtin_dir = Path(paths_cfg.get("abilities_builtin", builtin_dir))
             generated_dir = Path(paths_cfg.get("abilities_generated", generated_dir))

--- a/tests/core/test_centralized_config_usage.py
+++ b/tests/core/test_centralized_config_usage.py
@@ -1,0 +1,50 @@
+import yaml
+from pathlib import Path
+
+from agent_world.config import load_config
+from agent_world.main import bootstrap
+from agent_world.persistence import event_log
+
+
+def test_centralized_config_application(monkeypatch, tmp_path):
+    cfg = {
+        "world": {"size": [5, 5]},
+        "llm": {
+            "mode": "offline",
+            "agent_decision_model": "agent-test-model",
+            "angel_generation_model": "angel-test-model",
+        },
+        "paths": {
+            "abilities_builtin": str(tmp_path / "builtin"),
+            "abilities_generated": str(tmp_path / "generated"),
+            "abilities_vault": str(tmp_path / "vault"),
+        },
+        "cache": {"log_retention_mb": 1},
+    }
+
+    for p in cfg["paths"].values():
+        Path(p).mkdir(parents=True, exist_ok=True)
+
+    config_file = tmp_path / "cfg.yaml"
+    config_file.write_text(yaml.dump(cfg))
+
+    custom_config = load_config(config_file)
+    monkeypatch.setattr("agent_world.config.CONFIG", custom_config, raising=False)
+    monkeypatch.setattr(event_log, "CONFIG", custom_config, raising=False)
+
+    world = bootstrap(config_path=config_file)
+
+    llm = world.llm_manager_instance
+    assert llm.agent_decision_model == "agent-test-model"
+    assert llm.angel_generation_model == "angel-test-model"
+
+    ability_sys = world.ability_system_instance
+    expected_dirs = [
+        Path(cfg["paths"]["abilities_builtin"]),
+        Path(cfg["paths"]["abilities_generated"]),
+        Path(cfg["paths"]["abilities_vault"]),
+    ]
+    assert ability_sys.search_dirs == expected_dirs
+
+    assert event_log._log_retention_bytes() == 1 * 1024 * 1024
+


### PR DESCRIPTION
## Summary
- centralize config access in bootstrap and subsystems
- update LLMManager to use Config objects
- allow AbilitySystem to pull ability paths from Config
- fetch log retention from Config
- test centralized config usage

## Testing
- `PYTHONPATH=$(pwd) pytest -q tests/core tests/systems`