### PR TITLE
Task 9-A-4: remove player entity assumptions

### DIFF
--- a/agent_world/systems/ai/actions.py
+++ b/agent_world/systems/ai/actions.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from collections import deque
-from typing import Deque, Optional, Union, List 
-
-# ID used by the GUI input handler for the local player controller
-PLAYER_ID = 0
+from typing import Deque, Optional, Union, List
 
 
 # ------------------------------------------------------------------
@@ -187,5 +184,5 @@ class ActionQueue:
 __all__ = [
     "MoveAction", "AttackAction", "LogAction", "IdleAction", 
     "GenerateAbilityAction", "UseAbilityAction", "PickupAction", "Action",
-    "ActionQueue", "parse_action_string", "PLAYER_ID",
+    "ActionQueue", "parse_action_string",
 ]

--- a/agent_world/utils/cli/commands.py
+++ b/agent_world/utils/cli/commands.py
@@ -13,7 +13,6 @@ from ...core.components.ai_state import AIState # For spawning NPCs with AI
 from ...core.components.physics import Physics # For spawning NPCs with Physics
 from ...core.components.perception_cache import PerceptionCache # <<< ADDED
 from ...systems.interaction.pickup import Tag
-from ...systems.ai.actions import PLAYER_ID
 from ...core.components.role import RoleComponent
 from ...core.components.known_abilities import KnownAbilitiesComponent
 import yaml
@@ -190,13 +189,6 @@ def spawn(world: Any, kind: str, x_str: str | None = None, y_str: str | None = N
 
     spatial_index.insert(ent_id, (x, y))
 
-    if cm and not cm.get_component(PLAYER_ID, Position) and em.has_entity(PLAYER_ID):
-        player_default_pos = (world.size[0] // 2 -1 , world.size[1] // 2) if hasattr(world, 'size') else (-1,0)
-        cm.add_component(PLAYER_ID, Position(*player_default_pos))
-        if not cm.get_component(PLAYER_ID, Physics):
-            cm.add_component(PLAYER_ID, Physics(mass=1.0, vx=0.0, vy=0.0, friction=0.95))
-        spatial_index.insert(PLAYER_ID, player_default_pos)
-        # print(f"PLAYER_ID ({PLAYER_ID}) Position and Physics components ensured at {player_default_pos}.") # Can be verbose
     return ent_id
 
 

--- a/tests/core/test_player_id_removal.py
+++ b/tests/core/test_player_id_removal.py
@@ -1,0 +1,35 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.spatial.spatial_index import SpatialGrid
+from agent_world.core.components.position import Position
+from agent_world.core.components.physics import Physics
+from agent_world.utils.cli import commands
+import agent_world.systems.ai.actions as actions
+
+
+def _setup_world():
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.spatial_index = SpatialGrid(1)
+    return world
+
+
+def test_actions_module_has_no_player_id_constant():
+    assert not hasattr(actions, "PLAYER_ID")
+
+
+def test_spawn_does_not_modify_entity_zero():
+    world = _setup_world()
+    # Simulate a legacy player entity with ID 0
+    world.entity_manager._entity_components[0] = {}
+    world.component_manager._components[0] = {}
+
+    spawned_id = commands.spawn(world, "npc")
+    assert spawned_id is not None
+
+    cm = world.component_manager
+    assert cm.get_component(0, Position) is None
+    assert cm.get_component(0, Physics) is None
+    assert 0 not in world.spatial_index._entity_pos


### PR DESCRIPTION
## Summary
- drop PLAYER_ID constant and related exports
- stop CLI spawn from ensuring entity `0` components
- add regression tests confirming absence of PLAYER_ID constant and no player modification

## Testing
- `pytest -q tests/core tests/systems`