### PR TITLE
TASK 10-S-2: add conceptual testing stub

### DIFF
--- a/agent_world/ai/angel/system.py
+++ b/agent_world/ai/angel/system.py
@@ -12,6 +12,7 @@ from .vault_index import get_vault_index
 from ...core.components.known_abilities import KnownAbilitiesComponent
 from ...core.components.ai_state import AIState
 from ...persistence.event_log import append_event, ANGEL_ACTION
+from ...utils.sandbox import run_in_sandbox
 
 
 class AngelSystem:
@@ -142,6 +143,15 @@ class AngelSystem:
     ) -> str:
         """Return an LLM prompt for generating ability code."""
         return ""
+
+    # ------------------------------------------------------------------
+    # Conceptual testing stub
+    # ------------------------------------------------------------------
+    def _conceptual_test_generated_code(
+        self, generated_code: str, original_request: str
+    ) -> bool:
+        """Return True if generated code passes conceptual tests."""
+        return True
 
 
 def get_angel_system(world: Any) -> AngelSystem:

--- a/tests/angel/test_angel_conceptual_test_stub.py
+++ b/tests/angel/test_angel_conceptual_test_stub.py
@@ -1,0 +1,10 @@
+from agent_world.core.world import World
+from agent_world.ai.angel.system import get_angel_system, run_in_sandbox
+
+
+def test_conceptual_test_stub_callable():
+    world = World((5, 5))
+    system = get_angel_system(world)
+    assert callable(run_in_sandbox)
+    result = system._conceptual_test_generated_code("print('hi')", "dummy")
+    assert result is True


### PR DESCRIPTION
## Summary
- stub out _conceptual_test_generated_code on `AngelSystem`
- expose sandbox `run_in_sandbox` to the Angel system
- verify conceptual test stub is callable

## Testing
- `pytest -q tests/core tests/systems`
- `pytest -q tests/angel/test_angel_conceptual_test_stub.py`