### PR TITLE
Implement LLM-based planning

### DIFF
--- a/agent_world/ai/planning/llm_planner.py
+++ b/agent_world/ai/planning/llm_planner.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""LLM-backed planner for generating action plans."""
+
+from typing import Any, List
+
+from .base_planner import BasePlanner
+from ..llm.llm_manager import LLMManager
+from ...core.components.ai_state import Goal, ActionStep
+
+
+class LLMPlanner(BasePlanner):
+    """Use an LLM to convert goals into a list of :class:`ActionStep`."""
+
+    def __init__(self, llm: LLMManager) -> None:
+        self.llm = llm
+
+    def _parse_plan_text(self, text: str) -> List[ActionStep]:
+        steps: List[ActionStep] = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            action = parts[0]
+            target = None
+            params: dict[str, Any] = {}
+            if len(parts) > 1:
+                arg = parts[1]
+                if arg.isdigit():
+                    target = int(arg)
+                else:
+                    params["arg"] = arg
+            steps.append(ActionStep(action=action, target=target, parameters=params))
+        return steps
+
+    def create_plan(self, agent_id: int, goals: List[Goal], world: Any) -> List[ActionStep]:
+        goal_lines = [f"- {g.type}{(' ' + str(g.target)) if g.target is not None else ''}" for g in goals]
+        goal_text = "\n".join(goal_lines) if goal_lines else "None"
+        prompt = (
+            f"Plan steps for agent {agent_id} to achieve the following goals:\n{goal_text}\n"
+            "Respond with one action step per line in the format 'ACTION [arg]'"
+        )
+        response = self.llm.request(prompt, world, model=self.llm.agent_decision_model)
+        if not response or response.startswith("<"):
+            return []
+        return self._parse_plan_text(response)
+
+
+__all__ = ["LLMPlanner"]

--- a/tests/ai/planning/test_llm_planner.py
+++ b/tests/ai/planning/test_llm_planner.py
@@ -1,0 +1,62 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.components.ai_state import AIState, Goal
+from agent_world.core.components.role import RoleComponent
+from agent_world.ai.planning.llm_planner import LLMPlanner
+from agent_world.systems.ai.ai_reasoning_system import AIReasoningSystem
+
+
+class DummyLLM:
+    def __init__(self):
+        self.mode = "live"
+        self.prompts = []
+        self.agent_decision_model = "test-model"
+
+    def request(self, prompt: str, world: World, *, model: str | None = None):
+        self.prompts.append(prompt)
+        if "Plan" in prompt:
+            return "MOVE N"
+        return "IDLE"
+
+
+def _setup_world(llm: DummyLLM) -> World:
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    world.llm_manager_instance = llm
+    world.async_llm_responses = {}
+    world.raw_actions_with_actor = []
+    return world
+
+
+def test_llm_planner_creates_steps():
+    llm = DummyLLM()
+    planner = LLMPlanner(llm)
+    world = World((5, 5))
+    steps = planner.create_plan(1, [Goal("test", 1)], world)
+    assert steps and steps[0].action == "MOVE"
+    assert steps[0].parameters.get("arg") == "N"
+
+
+def test_reasoning_system_uses_plan():
+    llm = DummyLLM()
+    world = _setup_world(llm)
+    system = AIReasoningSystem(world, llm, world.raw_actions_with_actor)
+
+    agent = world.entity_manager.create_entity()
+    state = AIState(personality="p", goals=[Goal("move")])
+    world.component_manager.add_component(agent, state)
+    world.component_manager.add_component(agent, RoleComponent("npc"))
+
+    world.time_manager.tick_counter = 0
+    system.update(0)
+
+    assert world.raw_actions_with_actor
+    actor, action = world.raw_actions_with_actor[0]
+    assert actor == agent
+    assert action == "MOVE N"
+    # planner prompt should have been called once
+    assert len(llm.prompts) == 1


### PR DESCRIPTION
## Summary
- implement `LLMPlanner` for creating action plans from goals
- integrate planner with `AIReasoningSystem`
- use plan steps before querying the LLM
- add tests for planner creation and plan execution

## Testing
- `pytest -q tests/core tests/systems tests/ai/planning/test_llm_planner.py`