### PR TITLE
TASK 11-A-3: add generic fallback behavior trees

### DIFF
--- a/agent_world/ai/behaviors/generic_bt.py
+++ b/agent_world/ai/behaviors/generic_bt.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ...systems.ai.behavior_tree import (
+    Action,
+    BehaviorTree,
+    Selector,
+    fallback_explore_action,
+)
+from ...core.components.position import Position
+from ...core.components.health import Health
+from ...systems.interaction.pickup import Tag
+
+
+def _nearest_resource(world: Any, pos: tuple[int, int]) -> tuple[Optional[tuple[int, int]], Optional[str]]:
+    tile_map = getattr(world, "tile_map", None)
+    if not tile_map:
+        return None, None
+    best_pos: Optional[tuple[int, int]] = None
+    best_kind: Optional[str] = None
+    best_dist2: Optional[int] = None
+    for y, row in enumerate(tile_map):
+        for x, tile in enumerate(row):
+            if tile and "kind" in tile:
+                dist2 = (x - pos[0]) ** 2 + (y - pos[1]) ** 2
+                if best_dist2 is None or dist2 < best_dist2:
+                    best_dist2 = dist2
+                    best_pos = (x, y)
+                    best_kind = tile["kind"]
+    return best_pos, best_kind
+
+
+def _direction_towards(src: tuple[int, int], dst: tuple[int, int]) -> str:
+    dx = dst[0] - src[0]
+    dy = dst[1] - src[1]
+    if abs(dx) > abs(dy):
+        return "E" if dx > 0 else "W"
+    if dy != 0:
+        return "S" if dy > 0 else "N"
+    return "N"
+
+
+def _direction_away(src: tuple[int, int], dst: tuple[int, int]) -> str:
+    dx = src[0] - dst[0]
+    dy = src[1] - dst[1]
+    if abs(dx) > abs(dy):
+        return "E" if dx > 0 else "W"
+    if dy != 0:
+        return "S" if dy > 0 else "N"
+    return "N"
+
+
+def _gather_resource_action(agent_id: int, world: Any) -> Optional[str]:
+    cm = getattr(world, "component_manager", None)
+    if cm is None:
+        return None
+    pos = cm.get_component(agent_id, Position)
+    if pos is None:
+        return None
+    tile_map = getattr(world, "tile_map", None)
+    if tile_map:
+        tile = tile_map[pos.y][pos.x]
+        if tile and "kind" in tile:
+            return f"HARVEST {tile['kind']}"
+    target, _kind = _nearest_resource(world, (pos.x, pos.y))
+    if target is None:
+        return None
+    direction = _direction_towards((pos.x, pos.y), target)
+    return f"MOVE {direction}"
+
+
+def _flee_low_health_action(agent_id: int, world: Any, threshold: float = 0.3, radius: int = 3) -> Optional[str]:
+    cm = getattr(world, "component_manager", None)
+    index = getattr(world, "spatial_index", None)
+    if cm is None or index is None:
+        return None
+    hp = cm.get_component(agent_id, Health)
+    pos = cm.get_component(agent_id, Position)
+    if hp is None or pos is None or hp.max <= 0 or hp.cur / hp.max > threshold:
+        return None
+    nearest_pos: Optional[Position] = None
+    nearest_dist2: Optional[int] = None
+    for other in index.query_radius((pos.x, pos.y), radius):
+        if other == agent_id:
+            continue
+        o_pos = cm.get_component(other, Position)
+        if o_pos is None:
+            continue
+        dist2 = (o_pos.x - pos.x) ** 2 + (o_pos.y - pos.y) ** 2
+        if nearest_dist2 is None or dist2 < nearest_dist2:
+            nearest_dist2 = dist2
+            nearest_pos = o_pos
+    if nearest_pos is None:
+        return None
+    direction = _direction_away((pos.x, pos.y), (nearest_pos.x, nearest_pos.y))
+    return f"MOVE {direction}"
+
+
+def _item_interaction_action(agent_id: int, world: Any, search_radius: int = 5) -> Optional[str]:
+    cm = getattr(world, "component_manager", None)
+    index = getattr(world, "spatial_index", None)
+    if cm is None or index is None:
+        return None
+    pos = cm.get_component(agent_id, Position)
+    if pos is None:
+        return None
+    for other in index.query_radius((pos.x, pos.y), 0):
+        if other == agent_id:
+            continue
+        tag = cm.get_component(other, Tag)
+        if tag and tag.name == "item":
+            return f"PICKUP {other}"
+    nearest: Optional[Position] = None
+    best_dist2: Optional[int] = None
+    for other in index.query_radius((pos.x, pos.y), search_radius):
+        if other == agent_id:
+            continue
+        tag = cm.get_component(other, Tag)
+        if tag and tag.name == "item":
+            o_pos = cm.get_component(other, Position)
+            if o_pos is None:
+                continue
+            dist2 = (o_pos.x - pos.x) ** 2 + (o_pos.y - pos.y) ** 2
+            if best_dist2 is None or dist2 < best_dist2:
+                best_dist2 = dist2
+                nearest = o_pos
+    if nearest is None:
+        return None
+    direction = _direction_towards((pos.x, pos.y), (nearest.x, nearest.y))
+    return f"MOVE {direction}"
+
+
+def build_resource_gather_tree() -> BehaviorTree:
+    root = Selector([
+        Action(_gather_resource_action),
+        Action(fallback_explore_action),
+    ])
+    return BehaviorTree(root)
+
+
+def build_flee_low_health_tree() -> BehaviorTree:
+    root = Selector([
+        Action(_flee_low_health_action),
+        Action(fallback_explore_action),
+    ])
+    return BehaviorTree(root)
+
+
+def build_item_interaction_tree() -> BehaviorTree:
+    root = Selector([
+        Action(_item_interaction_action),
+        Action(fallback_explore_action),
+    ])
+    return BehaviorTree(root)
+
+
+__all__ = [
+    "build_resource_gather_tree",
+    "build_flee_low_health_tree",
+    "build_item_interaction_tree",
+]

--- a/tests/ai/test_expanded_behavior_trees.py
+++ b/tests/ai/test_expanded_behavior_trees.py
@@ -1,0 +1,100 @@
+from agent_world.core.world import World
+from agent_world.core.entity_manager import EntityManager
+from agent_world.core.component_manager import ComponentManager
+from agent_world.core.time_manager import TimeManager
+from agent_world.core.spatial.spatial_index import SpatialGrid
+from agent_world.core.components.ai_state import AIState
+from agent_world.core.components.role import RoleComponent
+from agent_world.core.components.position import Position
+from agent_world.core.components.health import Health
+from agent_world.systems.ai.behavior_tree_system import BehaviorTreeSystem
+from agent_world.ai.behaviors.generic_bt import (
+    build_resource_gather_tree,
+    build_flee_low_health_tree,
+    build_item_interaction_tree,
+)
+from agent_world.systems.interaction.pickup import Tag
+
+
+def _setup_world() -> World:
+    world = World((5, 5))
+    world.entity_manager = EntityManager()
+    world.component_manager = ComponentManager()
+    world.time_manager = TimeManager()
+    world.spatial_index = SpatialGrid(cell_size=1)
+    world.raw_actions_with_actor = []
+    return world
+
+
+def test_gather_tree_moves_and_harvests():
+    world = _setup_world()
+    tree = build_resource_gather_tree()
+    system = BehaviorTreeSystem(world, default_tree=tree)
+
+    agent = world.entity_manager.create_entity()
+    cm = world.component_manager
+    cm.add_component(agent, AIState(personality="bot"))
+    cm.add_component(agent, RoleComponent("worker", uses_llm=False))
+    cm.add_component(agent, Position(0, 1))
+
+    world.tile_map[1][2] = {"kind": "ore"}
+
+    system.update(0)
+    assert world.raw_actions_with_actor
+    actor, action = world.raw_actions_with_actor.pop()
+    assert actor == agent
+    assert action == "MOVE E"
+
+    cm.get_component(agent, Position).x = 2
+    system.update(1)
+    actor, action = world.raw_actions_with_actor.pop()
+    assert action.startswith("HARVEST")
+
+
+def test_flee_tree_moves_away_from_enemy():
+    world = _setup_world()
+    tree = build_flee_low_health_tree()
+    system = BehaviorTreeSystem(world, default_tree=tree)
+
+    agent = world.entity_manager.create_entity()
+    enemy = world.entity_manager.create_entity()
+    cm = world.component_manager
+    cm.add_component(agent, AIState(personality="bot"))
+    cm.add_component(agent, RoleComponent("scout", uses_llm=False))
+    cm.add_component(agent, Position(1, 1))
+    cm.add_component(agent, Health(cur=2, max=10))
+    world.spatial_index.insert(agent, (1, 1))
+
+    cm.add_component(enemy, Position(2, 1))
+    cm.add_component(enemy, Health(cur=5, max=5))
+    world.spatial_index.insert(enemy, (2, 1))
+
+    system.update(0)
+    assert world.raw_actions_with_actor
+    actor, action = world.raw_actions_with_actor.pop()
+    assert actor == agent
+    assert action == "MOVE W"
+
+
+def test_item_interaction_pickup():
+    world = _setup_world()
+    tree = build_item_interaction_tree()
+    system = BehaviorTreeSystem(world, default_tree=tree)
+
+    agent = world.entity_manager.create_entity()
+    item = world.entity_manager.create_entity()
+    cm = world.component_manager
+    cm.add_component(agent, AIState(personality="bot"))
+    cm.add_component(agent, RoleComponent("scout", uses_llm=False))
+    cm.add_component(agent, Position(0, 0))
+    world.spatial_index.insert(agent, (0, 0))
+
+    cm.add_component(item, Position(0, 0))
+    cm.add_component(item, Tag("item"))
+    world.spatial_index.insert(item, (0, 0))
+
+    system.update(0)
+    assert world.raw_actions_with_actor
+    actor, action = world.raw_actions_with_actor.pop()
+    assert actor == agent
+    assert action == f"PICKUP {item}"


### PR DESCRIPTION
## Summary
- add new generic behavior trees (resource gather, flee low HP, item interaction)
- export the builders under ai.behaviors
- test new behavior trees

## Testing
- `pytest -q tests/core tests/systems tests/ai/test_expanded_behavior_trees.py`