### PR TITLE
TASK 11.5-S-1: extend AIState and ActionStep

### DIFF
--- a/agent_world/ai/planning/base_planner.py
+++ b/agent_world/ai/planning/base_planner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, List
 
+# ``ActionStep`` includes an optional ``step_type`` field used by planners in
+# Phase 11.5 and later.
 from ...core.components.ai_state import Goal, ActionStep
 
 

--- a/agent_world/core/components/ai_state.py
+++ b/agent_world/core/components/ai_state.py
@@ -23,6 +23,7 @@ class ActionStep:
     action: str
     target: int | None = None
     parameters: dict[str, Any] = field(default_factory=dict)
+    step_type: str | None = None
 
 @dataclass(slots=True)
 class AIState:
@@ -37,3 +38,6 @@ class AIState:
     last_bt_move_failed: bool = False # Flag if last BT move resulted in no actual movement (e.g. collision)
     needs_immediate_rethink: bool = False
     last_error: str | None = None
+    plan_step_retries: int = 0
+    max_plan_step_retries: int = 3
+    last_plan_generation_tick: int = -1

--- a/tests/ai/planning/test_plan_execution_stubs.py
+++ b/tests/ai/planning/test_plan_execution_stubs.py
@@ -1,0 +1,14 @@
+from agent_world.core.components.ai_state import AIState, ActionStep
+
+
+def test_ai_state_retry_and_generation_fields():
+    state = AIState(personality="test")
+    assert state.plan_step_retries == 0
+    assert state.max_plan_step_retries == 3
+    assert state.last_plan_generation_tick == -1
+
+
+def test_action_step_has_optional_type():
+    step = ActionStep(action="MOVE")
+    assert hasattr(step, "step_type")
+    assert step.step_type is None


### PR DESCRIPTION
## Notes
- Core tests fail due to configuration mismatch unrelated to this task:
  `tests/core/test_config_keys.py::test_config_contains_new_keys` and `tests/core/test_config_module.py::test_config_module_loads_config` expect default models but `config.yaml` specifies `google/gemini-flash-1.5-8b`.
- Added new stub tests which pass.

## Summary
- added a `step_type` field to `ActionStep`
- extended `AIState` with retry and plan generation tracking fields
- documented the new `ActionStep` field in `BasePlanner`
- created tests covering the new AI state fields and the optional step type

## Testing
- `PYTHONPATH=. pytest -q tests/core tests/systems` *(fails: config mismatch)*
- `PYTHONPATH=. pytest -q tests/ai/planning/test_planner_stubs.py tests/ai/planning/test_plan_execution_stubs.py`