### PR TITLE
Fix BT fallback when LLM pending

### DIFF
--- a/tests/systems/ai/test_generate_ability_trigger.py
+++ b/tests/systems/ai/test_generate_ability_trigger.py
@@ -48,7 +48,7 @@ def test_contextualize_generate_ability_from_plan_step():
     step = ActionStep(
         action="WAIT",
         step_type="DEAL_WITH_OBSTACLE",
-        parameters={"obstacle": "(2,1)", "goal": "(2,0)"},
+        parameters={"coords": (2, 1), "goal": "(2,0)"},
     )
     ai_state = AIState(personality="bot", current_plan=[step])
     world.component_manager.add_component(agent, ai_state)
@@ -61,7 +61,7 @@ def test_contextualize_generate_ability_from_plan_step():
     assert actor == agent
     assert action.startswith("GENERATE_ABILITY")
     assert "(2,1)" in action
-    assert "(2,0)" in action
+    assert "goal target (2,0)" in action
 
 
 def test_contextualize_generate_ability_general_obstacle():
@@ -86,6 +86,6 @@ def test_contextualize_generate_ability_general_obstacle():
     assert actor == agent
     assert action.startswith("GENERATE_ABILITY")
     assert "(2,1)" in action
-    assert "(2,0)" in action
+    assert "goal target 2" in action
 
     clear_obstacles()

--- a/tests/systems/test_role_gating.py
+++ b/tests/systems/test_role_gating.py
@@ -9,7 +9,8 @@ from agent_world.core.component_manager import ComponentManager
 from agent_world.core.time_manager import TimeManager
 from agent_world.core.components.ai_state import AIState
 from agent_world.core.components.role import RoleComponent
-from agent_world.systems.ai.ai_reasoning_system import AIReasoningSystem
+from agent_world.systems.ai.ai_reasoning_system import AIReasoningSystem, RawActionCollector
+from agent_world.systems.ai.actions import ActionQueue
 
 
 class DummyLLM:
@@ -29,7 +30,8 @@ def _setup_world(llm: DummyLLM) -> World:
     world.time_manager = TimeManager()
     world.llm_manager_instance = llm
     world.async_llm_responses = {}
-    world.raw_actions_with_actor = []
+    world.action_queue = ActionQueue()
+    world.raw_actions_with_actor = RawActionCollector(world.action_queue)
     return world
 
 


### PR DESCRIPTION
## Summary
- avoid running behavior tree while waiting for LLM
- keep raw action logging when queueing actions directly
- ensure ability generation context uses plan step info
- update tests for new parameters and behaviours

## Testing
- `pytest -q tests/core tests/systems`